### PR TITLE
Don't hide 'is_recur' option on Contribution Pages

### DIFF
--- a/sepa.php
+++ b/sepa.php
@@ -38,11 +38,6 @@ function _sepa_buildForm_Contribution_Main ($formName, &$form ){
     ,array("version"=>3,"id"=>$form->_values["payment_processor"]));
   if("Payment_SEPA_DD" != $pp["class_name"])
     return;
-  //$form->getElement('is_recur')->setValue(1); // recurring contrib as an option
-  if (isset($form->_elementIndex['is_recur'])) {
-    $form->removeElement('is_recur'); // force recurring contrib
-  }
-  $form->addElement('hidden','is_recur',1);
   //workaround the notice message, as ContributionBase assumes these fields exist in the confirm step
   foreach (array("account_holder","bank_identification_number","bank_name","bank_account_number") as $field){
     $form->addElement("hidden",$field);


### PR DESCRIPTION
Apart from the fact that we want to support one-off contributions as
well soonish, hiding the recur option has the undesirable side effect of
also making the recur frequency settings unavailable -- but we need
these. (See issue #44)

While some organisations might want to enforce only monthly
contributions, such customisations should be implemented locally for
these organisations (or with a new option in core) -- it's not something
to be dictated by the Payment Processor...
