### PR TITLE
Fix for header in event ThankYou page

### DIFF
--- a/templates/CRM/Event/Form/RegistrationThankYou.sepa.tpl
+++ b/templates/CRM/Event/Form/RegistrationThankYou.sepa.tpl
@@ -18,7 +18,7 @@
 
 <div class="crm-section sepa-section no-label">
   <br/>
-  <h2>{ts}Direct Debit Payment{/ts}</h2>
+  <div class="header-dark">{ts}Direct Debit Payment{/ts}</div>
   <table class="sepa-confirm-text-account-details display" id="sepa-confirm-text-account-details">
     <tr id="sepa-thankyou-amount">
       <td>{ts}Amount{/ts}</td>


### PR DESCRIPTION
The event Thank You screen layout has a little flaw.
The header for Direct Debit Payments is missing the prober css (class="header-dark")
![civicrm-sepa_thankyouheader](https://cloud.githubusercontent.com/assets/2195908/7412599/b0498b9c-ef44-11e4-852b-9d4041d1670d.png)
