### PR TITLE
Fix for missing contactID in 4.6

### DIFF
--- a/CRM/Core/Payment/SDD.php
+++ b/CRM/Core/Payment/SDD.php
@@ -152,7 +152,7 @@ class CRM_Core_Payment_SDD extends CRM_Core_Payment {
 
     // prepare the creation of an incomplete mandate
     $params['creditor_id']   = $this->_creditorId;
-    $params['contact_id']    = $this->getForm()->getVar('_contactID');
+    $params['contact_id']    = $params['contactID'];
     $params['source']        = $params['description'];
     $params['iban']          = $params['bank_account_number'];
     $params['bic']           = $params['bank_identification_number'];


### PR DESCRIPTION
The code broke in 4.6 over the folllowing line:
$params['contact_id'] = $this->getForm()->getVar('_contactID');
Changed that to:
$params['contact_id']    = $params['contactID'];