### PR TITLE
payment processor should not ignore cycle_day parameter

### DIFF
--- a/CRM/Core/Payment/SDD.php
+++ b/CRM/Core/Payment/SDD.php
@@ -199,6 +199,7 @@ class CRM_Core_Payment_SDD extends CRM_Core_Payment {
       civicrm_api3('ContributionRecur', 'create', array(
         'id'            => $params['contributionRecurID'], 
         'start_date'    => $params['sepa_start_date'],
+        'cycle_day'     => $params['cycle_day'],
         'trxn_id'       => $params['trxn_id']));
     }
 


### PR DESCRIPTION
This should fix #274. Compatible with 4.4.11 - 4.6.