### PR TITLE
Set up default mandate type to recurring on create form

### DIFF
--- a/CRM/Sepa/Page/CreateMandate.php
+++ b/CRM/Sepa/Page/CreateMandate.php
@@ -195,7 +195,7 @@ class CRM_Sepa_Page_CreateMandate extends CRM_Core_Page {
     // first, try to load contact
     $contact = civicrm_api('Contact', 'getsingle', array('version' => 3, 'id' => $contact_id));
     if (isset($contact['is_error']) && $contact['is_error']) {
-      CRM_Core_Session::setStatus(sprintf(ts("Couldn't find contact #%s"), $cid), ts('Error'), 'error');
+      CRM_Core_Session::setStatus(sprintf(ts("Couldn't find contact #%s"), $contact_id), ts('Error'), 'error');
       $this->assign("display_name", "ERROR");
       return;
     }
@@ -208,7 +208,7 @@ class CRM_Sepa_Page_CreateMandate extends CRM_Core_Page {
     $campaigns = array();
     $campaigns[''] = ts("No Campaign");
     if (isset($campaign_query['is_error']) && $campaign_query['is_error']) {
-      CRM_Core_Session::setStatus(sprintf(ts("Couldn't load campaign list."), $cid), ts('Error'), 'error');      
+      CRM_Core_Session::setStatus(ts("Couldn't load campaign list."), ts('Error'), 'error');
     } else {
       foreach ($campaign_query['values'] as $campaign_id => $campaign) {
         $campaigns[$campaign_id] = $campaign['title'];
@@ -269,7 +269,7 @@ class CRM_Sepa_Page_CreateMandate extends CRM_Core_Page {
     $creditor_query = civicrm_api('SepaCreditor', 'get', array('version' => 3));
     $creditors = array();
     if (isset($creditor_query['is_error']) && $creditor_query['is_error']) {
-      CRM_Core_Session::setStatus(sprintf(ts("Couldn't find any creditors."), $cid), ts('Error'), 'error');
+      CRM_Core_Session::setStatus(ts("Couldn't find any creditors."), ts('Error'), 'error');
     } else {
       foreach ($creditor_query['values'] as $creditor_id => $creditor) {
         $creditors[$creditor_id] = $creditor['name'];
@@ -302,6 +302,8 @@ class CRM_Sepa_Page_CreateMandate extends CRM_Core_Page {
         $this->assign('creditor_id', $default_creditor->id);
       }
     }
+
+    $this->assign('mandate_type', isset($_REQUEST['mandate_type']) ? $_REQUEST['mandate_type'] : 'RCUR');
   }
 
 


### PR DESCRIPTION
SEPA Direct Debit is designed to provide recurring payments.

We found out that users often forget about changing mandate type from `One time` to `Recurring` during creating new mandate.