### PR TITLE
Add multi currency functionality

### DIFF
--- a/CRM/Admin/Form/Setting/SepaSettings.php
+++ b/CRM/Admin/Form/Setting/SepaSettings.php
@@ -116,6 +116,13 @@ class CRM_Admin_Form_Setting_SepaSettings extends CRM_Admin_Form_Setting
         // do not use array_merge() because it discards the original indizes
         $country_ids = array('' => ts('- select -')) + $filtered;
 
+        $config->defaultCurrency;
+        $currencies_enabled = CRM_Core_OptionGroup::values('currencies_enabled');
+        $currencies_dict = array('' => ts('- select -'));
+        foreach ((array)$currencies_enabled as $k => $v) {
+          $currencies_dict[$k] = $k;
+        }
+
         // look up some values
         $excld_we = CRM_Core_BAO_Setting::getItem('SEPA Direct Debit Preferences', 'exclude_weekends');
         $hide_bic = CRM_Core_BAO_Setting::getItem('SEPA Direct Debit Preferences', 'pp_hide_bic');
@@ -126,6 +133,7 @@ class CRM_Admin_Form_Setting_SepaSettings extends CRM_Admin_Form_Setting
         $this->addElement('text',       'addcreditor_id',           ts("Identifier"));
         $this->addElement('text',       'addcreditor_address',      ts("Address"), array('size' => 60));
         $this->addElement('select',     'addcreditor_country_id',   ts("Country"), $country_ids);
+        $this->addElement('select',     'addcreditor_currency',     ts("Currency"), $currencies_dict);
         $this->addElement('text',       'addcreditor_bic',          ts("BIC"));
         $this->addElement('text',       'addcreditor_iban',         ts("IBAN"), array('size' => 30));
         $this->addElement('select',     'addcreditor_pain_version', ts("PAIN Version"), array('' => ts('- select -')) + CRM_Core_OptionGroup::values('sepa_file_format'));

--- a/CRM/Sepa/BAO/SEPAMandate.php
+++ b/CRM/Sepa/BAO/SEPAMandate.php
@@ -322,7 +322,7 @@ class CRM_Sepa_BAO_SEPAMandate extends CRM_Sepa_DAO_SEPAMandate {
     $query = array(
       'version'   => 3,
       'id'        => $contribution_id,
-      'currency'  => 'EUR',
+      'currency'  => $contribution['currency'],
       'end_date'  => date('YmdHis', $new_end_date));
     if ($cancel_reason) {
       // FIXME: cancel_reason does not exist in contribution_recur!!
@@ -463,7 +463,7 @@ class CRM_Sepa_BAO_SEPAMandate extends CRM_Sepa_DAO_SEPAMandate {
       'version'   => 3,
       'id'        => $contribution_id,
       'amount'    => $adjusted_amount,
-      'currency'  => 'EUR');
+      'currency'  => $contribution['currency']);
     $result = civicrm_api("ContributionRecur", "create", $query);
     if (!empty($result['is_error'])) {
       CRM_Core_Session::setStatus(sprintf(ts("Cannot modify recurring contribution [%s]. Error was: '%s'"), $contribution_id, $result['error_message']), ts('Error'), 'error');

--- a/CRM/Sepa/DAO/SEPACreditor.php
+++ b/CRM/Sepa/DAO/SEPACreditor.php
@@ -304,6 +304,14 @@ class CRM_Sepa_DAO_SEPACreditor extends CRM_Core_DAO
             'optionGroupName' => 'sepa_file_format',
           )
         ) ,
+        'currency' => array(
+          'name' => 'currency',
+          'type' => CRM_Utils_Type::T_STRING,
+          'title' => ts('Currency') ,
+          'maxlength' => 3,
+          'size' => CRM_Utils_Type::FOUR,
+          'default' => 'EUR',
+        ) ,
       );
     }
     return self::$_fields;
@@ -333,6 +341,7 @@ class CRM_Sepa_DAO_SEPACreditor extends CRM_Core_DAO
         'tag' => 'tag',
         'mandate_active' => 'mandate_active',
         'sepa_file_format_id' => 'sepa_file_format_id',
+        'currency' => 'currency',
       );
     }
     return self::$_fieldKeys;

--- a/CRM/Sepa/Logic/Batching.php
+++ b/CRM/Sepa/Logic/Batching.php
@@ -321,7 +321,8 @@ class CRM_Sepa_Logic_Batching {
         mandate.entity_id AS mandate_entity_id,
         mandate.creation_date AS mandate_creation_date,
         mandate.validation_date AS mandate_validation_date,
-        rcontribution.end_date AS end_date
+        rcontribution.end_date AS end_date,
+        rcontribution.currency AS currency
       FROM civicrm_sdd_mandate AS mandate
       INNER JOIN civicrm_contribution_recur AS rcontribution       ON mandate.entity_id = rcontribution.id
       WHERE mandate.type = 'RCUR'
@@ -330,7 +331,15 @@ class CRM_Sepa_Logic_Batching {
     $results = CRM_Core_DAO::executeQuery($sql_query);
     $mandates_to_end = array();
     while ($results->fetch()) {
-      array_push($mandates_to_end, array('mandate_id'=>$results->mandate_id, 'recur_id'=>$results->mandate_entity_id, 'creation_date'=>$results->mandate_creation_date, 'validation_date'=>$results->mandate_validation_date, 'date'=>$results->mandate_date));
+      array_push($mandates_to_end, array(
+          'mandate_id' => $results->mandate_id,
+          'recur_id' => $results->mandate_entity_id,
+          'creation_date' => $results->mandate_creation_date,
+          'validation_date' => $results->mandate_validation_date,
+          'date' => $results->mandate_date,
+          'currency' => $results->currency,
+        )
+      );
     }
 
     // then, end them one by one
@@ -351,7 +360,7 @@ class CRM_Sepa_Logic_Batching {
         'id'                      => $mandate_to_end['recur_id'],
         'contribution_status_id'  => $contribution_status_closed,
         'modified_date'           => date('YmdHis'),
-        'currency'                => 'EUR',
+        'currency'                => $mandate_to_end['currency'],
         'version'                 => 3));
       if (isset($change_rcur['is_error']) && $change_rcur['is_error']) {
         $lock->release();

--- a/CRM/Sepa/Page/CreateMandate.php
+++ b/CRM/Sepa/Page/CreateMandate.php
@@ -87,6 +87,12 @@ class CRM_Sepa_Page_CreateMandate extends CRM_Core_Page {
     $payment_instrument_id = CRM_Core_OptionGroup::getValue('payment_instrument', $type, 'name');
     $contribution_status_id = CRM_Core_OptionGroup::getValue('contribution_status', 'Pending', 'name');
 
+    $params = array(
+      'id' => $_REQUEST['creditor_id'],
+      'return' => 'currency'
+    );
+    $creditor = civicrm_api3('SepaCreditor', 'getsingle', $params);
+
     $contribution_data = array(
         'version'                   => 3,
         'contact_id'                => $_REQUEST['contact_id'],
@@ -94,7 +100,7 @@ class CRM_Sepa_Page_CreateMandate extends CRM_Core_Page {
         'financial_type_id'         => $_REQUEST['financial_type_id'],
         'payment_instrument_id'     => $payment_instrument_id,
         'contribution_status_id'    => $contribution_status_id,
-        'currency'                  => 'EUR',
+        'currency'                  => $creditor['currency'],
       );
 
     if ($type=='OOFF') {
@@ -280,14 +286,17 @@ class CRM_Sepa_Page_CreateMandate extends CRM_Core_Page {
     // look up creditors
     $creditor_query = civicrm_api('SepaCreditor', 'get', array('version' => 3));
     $creditors = array();
+    $creditor_currency = array();
     if (isset($creditor_query['is_error']) && $creditor_query['is_error']) {
       CRM_Core_Session::setStatus(ts("Couldn't find any creditors."), ts('Error'), 'error');
     } else {
       foreach ($creditor_query['values'] as $creditor_id => $creditor) {
         $creditors[$creditor_id] = $creditor['name'];
+        $creditor_currency[$creditor_id] = $creditor['currency'];
       }
     }
     $this->assign('creditors', $creditors);
+    $this->assign('creditor_currency', json_encode($creditor_currency));
     
     // add cycle_days per creditor
     $creditor2cycledays = array();

--- a/CRM/Sepa/Page/ListGroup.php
+++ b/CRM/Sepa/Page/ListGroup.php
@@ -48,6 +48,7 @@ class CRM_Sepa_Page_ListGroup extends CRM_Core_Page {
         civicrm_contribution.id                 AS contribution_id,
         civicrm_contribution.total_amount       AS contribution_amount,
         civicrm_contribution.financial_type_id  AS contribution_financial_type_id,
+        civicrm_contribution.currency           AS contribution_currency,
         civicrm_campaign.title                  AS contribution_campaign
       FROM   
         civicrm_sdd_txgroup
@@ -70,6 +71,7 @@ class CRM_Sepa_Page_ListGroup extends CRM_Core_Page {
       $contact_base_link = CRM_Utils_System::url('civicrm/contact/view', '&reset=1&cid=');
       $contribution_base_link = CRM_Utils_System::url('civicrm/contact/view/contribution', '&reset=1&id=_cid_&cid=_id_&action=view');
 
+      $currency = '';
       $contributions = array();
       $result = CRM_Core_DAO::executeQuery($sql);
       while ($result->fetch()) {
@@ -81,7 +83,7 @@ class CRM_Sepa_Page_ListGroup extends CRM_Core_Page {
           'contribution_link'         => str_replace('_id_', $result->contact_id, str_replace('_cid_', $result->contribution_id, $contribution_base_link)),
           'contribution_id'           => $result->contribution_id,
           'contribution_amount'       => $result->contribution_amount,
-          'contribution_amount_str'   => CRM_Utils_Money::format($result->contribution_amount, 'EUR'),
+          'contribution_amount_str'   => CRM_Utils_Money::format($result->contribution_amount, $result->contribution_currency),
           'financial_type'            => $financial_types[$result->contribution_financial_type_id],
           'campaign'                  => $result->contribution_campaign,
         );
@@ -92,6 +94,7 @@ class CRM_Sepa_Page_ListGroup extends CRM_Core_Page {
         $total_contacts[$result->contact_id] = 1;
         $total_campaigns[$result->contribution_campaign] = 1;
         $reference = $result->reference;
+        $currency = $result->contribution_currency;
       }
     }
 
@@ -100,7 +103,7 @@ class CRM_Sepa_Page_ListGroup extends CRM_Core_Page {
     $this->assign("group_id", $group_id);
     $this->assign("total_count", $total_count);
     $this->assign("total_amount", $total_amount);
-    $this->assign("total_amount_str", CRM_Utils_Money::format($total_amount, 'EUR'));
+    $this->assign("total_amount_str", CRM_Utils_Money::format($total_amount, $currency));
     $this->assign("contributions", $contributions);
     $this->assign("different_campaigns", count($total_campaigns));
     $this->assign("different_types", count($total_types));

--- a/api/v3/SepaTransactionGroup.php
+++ b/api/v3/SepaTransactionGroup.php
@@ -118,11 +118,13 @@ function civicrm_api3_sepa_transaction_group_getdetail($params) {
       civicrm_sdd_file.created_date     AS file_created_date, 
       count(*)                          AS nb_contrib, 
       sum( contrib.total_amount)        AS total,
-      civicrm_sdd_file.reference        AS file
+      civicrm_sdd_file.reference        AS file,
+      civicrm_sdd_creditor.currency
     FROM civicrm_sdd_txgroup as txgroup 
     LEFT JOIN civicrm_sdd_contribution_txgroup as txgroup_contrib on txgroup.id = txgroup_contrib.txgroup_id 
     LEFT JOIN civicrm_contribution as contrib on txgroup_contrib.contribution_id = contrib.id 
-    LEFT JOIN civicrm_sdd_file on sdd_file_id = civicrm_sdd_file.id 
+    LEFT JOIN civicrm_sdd_file on sdd_file_id = civicrm_sdd_file.id
+    LEFT JOIN civicrm_sdd_creditor on sdd_creditor_id = civicrm_sdd_creditor.id
     WHERE $where 
     GROUP BY txgroup.id 
     $orderby;";

--- a/sql/sepa.sql
+++ b/sql/sepa.sql
@@ -18,7 +18,8 @@ CREATE TABLE IF NOT EXISTS `civicrm_sdd_creditor`(
      `category` varchar(4)    COMMENT 'Default value',
      `tag` varchar(64) NULL   COMMENT 'Place this creditor\'s transaction groups in an XML file tagged with this value.',
      `mandate_active` tinyint    COMMENT 'If true, new Mandates for this Creditor are set to active directly upon creation; otherwise, they have to be activated explicitly later on.',
-     `sepa_file_format_id` int unsigned    COMMENT 'Variant of the pain.008 format to use when generating SEPA XML files for this creditor. FK to SEPA File Formats in civicrm_option_value.'
+     `sepa_file_format_id` int unsigned    COMMENT 'Variant of the pain.008 format to use when generating SEPA XML files for this creditor. FK to SEPA File Formats in civicrm_option_value.',
+     `currency` varchar(3) NOT NULL DEFAULT 'EUR' COMMENT '3 character string symbol of currency'
 ,
     PRIMARY KEY ( `id` )
 

--- a/templates/CRM/Admin/Form/Setting/SepaSettings.tpl
+++ b/templates/CRM/Admin/Form/Setting/SepaSettings.tpl
@@ -101,6 +101,12 @@ div.sdd-add-creditor {
               </td>
             </tr>
             <tr>
+              <td class="label">{$form.addcreditor_currency.label} <a onclick='CRM.help("{ts}Currency{/ts}", {literal}{"id":"id-currency","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td>
+                {$form.addcreditor_currency.html}
+              </td>
+            </tr>
+            <tr>
               <td class="label">{$form.addcreditor_id.label} <a onclick='CRM.help("{ts}Creditor Identifier{/ts}", {literal}{"id":"id-id","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>
                 {$form.addcreditor_id.html}
@@ -437,6 +443,7 @@ div.sdd-add-creditor {
           cj('#addcreditor_name').val(data['name']);
           cj('#addcreditor_address').val(data['address']);
           cj('#addcreditor_country_id').val(data['country_id']);
+          cj('#addcreditor_currency').val(data['currency']);
           cj('#addcreditor_id').val(data['identifier']);
           cj('#addcreditor_iban').val(data['iban']);
           cj('#addcreditor_bic').val(data['bic']);
@@ -472,6 +479,7 @@ div.sdd-add-creditor {
     map["addcreditor_name"]         = "name";
     map["addcreditor_address"]      = "address";
     map["addcreditor_country_id"]   = "country_id";
+    map["addcreditor_currency"]     = "currency";
     map["addcreditor_id"]           = "identifier";
     map["addcreditor_iban"]         = "iban";
     map["addcreditor_bic"]          = "bic";

--- a/templates/CRM/Sepa/Page/CreateMandate.tpl
+++ b/templates/CRM/Sepa/Page/CreateMandate.tpl
@@ -35,7 +35,7 @@
 		<tr>	<!-- CREDITOR -->
 			<td>{ts}Creditor{/ts}:</td>
 			<td>
-				<select name="creditor_id" onChange='sepa_update_cycledays();' >
+				<select name="creditor_id" onChange='change_creditor();' >
 					{foreach from=$creditors item=name key=id}
 					<option value="{$id}" {if $id eq $creditor_id}selected{/if}>{$name}</option>
 					{/foreach}
@@ -48,7 +48,7 @@
 		</tr>
 		<tr>	<!-- AMOUNT -->
 			<td>{ts}Amount{/ts}:</td>
-			<td><input name="total_amount" type="number" size="6" step="0.01" value="{$total_amount}" />&nbsp;EUR</td>
+			<td><input name="total_amount" type="number" size="6" step="0.01" value="{$total_amount}" />&nbsp;<span id="creditor_currency">EUR</span></td>
 		</tr>
 		<tr>	<!-- FINANCIAL TYPE -->
 			<td>{ts}Financial Type{/ts}:</td>
@@ -207,11 +207,8 @@
 
 
 <script type="text/javascript">
-{if $creditor2cycledays}
-var creditor2cycledays = {$creditor2cycledays};
-{else}
-var creditor2cycledays = [];
-{/if}
+var creditor2cycledays = {if $creditor2cycledays}{$creditor2cycledays}{else}[]{/if};
+var creditor_currency = {if $creditor_currency}{$creditor_currency}{else}[]{/if};
 {literal}
 // logic for the bank account selector
 cj("#account").change(change_bank_account);
@@ -238,7 +235,15 @@ function sepa_update_cycledays() {
 		cj('#default_element_cycle_day').append('<option value="' + value + '" ' + is_selected + '>' + label + '.</option>');
 	}
 }
+function change_currency() {
+	cj("#creditor_currency").text(creditor_currency[cj("[name='creditor_id']").val()]);
+}
+function change_creditor() {
+	sepa_update_cycledays();
+	change_currency();
+}
 sepa_update_cycledays();
+change_currency();
 {/literal}
 
 // Validation handling

--- a/templates/CRM/Sepa/Page/DashBoard.tpl
+++ b/templates/CRM/Sepa/Page/DashBoard.tpl
@@ -83,7 +83,7 @@
   {/if}
     <td>{$group.collection_date}</td>
     <td class="nb_contrib" title="list all the contributions">{$group.nb_contrib}</td>
-    <td style="white-space:nowrap;">{$group.total|crmMoney:EUR}</td>
+    <td style="white-space:nowrap;">{$group.total|crmMoney:$group.currency}</td>
     <td>
       <a href="{crmURL p="civicrm/sepa/listgroup" q="group_id=$group_id"}" class="button button_view">{ts}Contributions{/ts}</a>
       {if $group.status == 'open'}

--- a/templates/CRM/Sepa/Page/EditMandate.tpl
+++ b/templates/CRM/Sepa/Page/EditMandate.tpl
@@ -122,7 +122,7 @@
             {if $can_modify}{if $contribution.cycle_day}{if $sepa.status eq 'FRST' or $sepa.status eq 'RCUR' or $sepa.status eq 'INIT'}<tr>
                 <td class="label" style="vertical-align: middle;"><a class="button" onclick="mandate_action_adjust_amount();">{ts}Adjust Amount{/ts}</td>
                 <td>
-                    {ts}Change amount to:{/ts}&nbsp;<input type="text" name="adjust_amount" id="adjust_amount" size="12" value="{$contribution.amount}" />&nbsp;EUR
+                    {ts}Change amount to:{/ts}&nbsp;<input type="text" name="adjust_amount" id="adjust_amount" size="12" value="{$contribution.amount}" />&nbsp;{$contribution.currency}
                 </td>
             </tr>{/if}{/if}{/if}
 

--- a/xml/schema/Sepa/Creditor.xml
+++ b/xml/schema/Sepa/Creditor.xml
@@ -151,4 +151,16 @@
     </pseudoconstant>
     <add>4.4</add>
   </field>
+
+  <field>
+    <name>currency</name>
+    <title>3 character string symbol of currency</title>
+    <type>varchar</type>
+    <required>true</required>
+    <length>3</length>
+    <default>"EUR"</default>
+    <comment>3 character string symbol of currency</comment>
+    <add>4.6</add>
+  </field>
+
 </table>


### PR DESCRIPTION
Multi currency functionality is required by Polish formats, for example for CitiBank. It's tested by our clients and works :-) 
This is next step of #319 

By the way, What is your prefered method of upgrading `SQL`? 

In this PR I added new column `civicrm_sdd_creditor.currency`, and only in `sql/sepa.sql` file which is used during installation. And what about upgrade?

```sql
ALTER TABLE civicrm_sdd_creditor ADD COLUMN `currency` VARCHAR(3) NOT NULL DEFAULT 'EUR' COMMENT '3 character string symbol of currency';
```