### PR TITLE
Fix filename when download again after close group

### DIFF
--- a/api/v3/SepaTransactionGroup.php
+++ b/api/v3/SepaTransactionGroup.php
@@ -118,6 +118,7 @@ function civicrm_api3_sepa_transaction_group_getdetail($params) {
       civicrm_sdd_file.created_date     AS file_created_date, 
       count(*)                          AS nb_contrib, 
       sum( contrib.total_amount)        AS total,
+      civicrm_sdd_file.filename         AS filename,
       civicrm_sdd_file.reference        AS file
     FROM civicrm_sdd_txgroup as txgroup 
     LEFT JOIN civicrm_sdd_contribution_txgroup as txgroup_contrib on txgroup.id = txgroup_contrib.txgroup_id 

--- a/templates/CRM/Sepa/Page/DashBoard.tpl
+++ b/templates/CRM/Sepa/Page/DashBoard.tpl
@@ -94,7 +94,7 @@
         {/if}
         {ts}Close and Submit{/ts}</a>
       {else}
-        <a href="{crmURL p="civicrm/sepa/xml" q="id=$file_id"}" download="{$group.file}.xml" class="button button_export">{ts}Download Again{/ts}</a>
+        <a href="{crmURL p="civicrm/sepa/xml" q="id=$file_id"}" download="{$group.filename}" class="button button_export">{ts}Download Again{/ts}</a>
         {if $closed_status_id eq $group.status_id}
           {if $group.collection_date|strtotime lt $smarty.now}
             <a id="mark_received_{$group_id}" onClick="mark_received({$group_id});" class="button button_export">{ts}Mark Received{/ts}</a>


### PR DESCRIPTION
Extension of file is configured on level of creditor and therefore in column `civicrm_sdd_file.filename` is a filename with proper extension. For example:

* `CITIBANK-TXG-2-FRST-2016-01-26`**.txt** in Citibank format
* `SEPA-TXG-2-FRST-2016-01-26`**.xml** in standard Sepa format

#319 