### PR TITLE
Fix bad link in summary action

### DIFF
--- a/sepa.php
+++ b/sepa.php
@@ -342,17 +342,25 @@ function sepa_civicrm_managed(&$entities) {
 }
 
 
-function sepa_civicrm_summaryActions( &$actions, $contactID ) {
-  // add "create SEPA mandate action"
-  $actions['sepa_contribution'] = array(
-      'title'           => ts("Record SEPA Contribution"),
-      'weight'          => 5,
-      'ref'             => 'new-sepa-contribution',
-      'key'             => 'sepa_contribution',
-      'component'       => 'CiviContribute',
-      'href'            => CRM_Utils_System::url('civicrm/sepa/cmandate', "cid=$contactID"),
-      'permissions'     => array('access CiviContribute', 'edit contributions')
+/**
+ * Implementation of hook_civicrm_links
+ *
+ * @param $op
+ * @param $objectName
+ * @param $objectId
+ * @param $links
+ * @param $mask
+ * @param $values
+ */
+function sepa_civicrm_links($op, $objectName, $objectId, &$links, &$mask, &$values) {
+  if ($op == 'contact.selector.actions') {
+    $links[] = array(
+      'name' => 'Record SEPA Contribution',
+      'url' => CRM_Utils_System::url('civicrm/sepa/cmandate', "cid=$objectId"),
+      'title' => 'Record SEPA Contribution',
+      'ref' => 'record-sepa-contribution',
     );
+  }
 }
 
 


### PR DESCRIPTION
Hi,

This is my proposal for resolving bad link in summary actions on "Find Contacts" page.

Problem: link `Record SEPA Contribution` is broken. It opens an unuseful window. In additional this link replaces default link `Add Contribution`
![links-more](https://cloud.githubusercontent.com/assets/8309610/13425668/a0e1a086-dfa8-11e5-96cb-7215981230be.png)
![popup1](https://cloud.githubusercontent.com/assets/8309610/13425599/463f63c0-dfa8-11e5-9fd8-11112836ecc8.png)

Fix: remove hook_civicrm_summaryAction and replace it by hook_civicrm_links. Proper link to `Create mandate` is placed on bottom of links:
![fix-link](https://cloud.githubusercontent.com/assets/8309610/13425607/50803a6c-dfa8-11e5-805f-12fb787e3b9c.png)

It's necessary to decide what to do with permissions. They are used in summaryActions but in hook with links we don't have such functionality. Is it essential?