### PR TITLE
Add legend and change colors on dashboard

### DIFF
--- a/templates/CRM/Sepa/Page/DashBoard.tpl
+++ b/templates/CRM/Sepa/Page/DashBoard.tpl
@@ -109,12 +109,41 @@
   {/foreach}
 </table>
 
+<table>
+  <caption>Legend</caption>
+  <tr>
+    <th>Status</th>
+    <th>Description</th>
+  </tr>
+  <tr class="submit_missed">
+    <td>Missed</td>
+    <td>Submission date is older than now.</td>
+  </tr>
+  <tr class="submit_urgently">
+    <td>Urgently</td>
+    <td>Submission date is current, you have to close group and upload file to creditor today.</td>
+  </tr>
+  <tr class="submit_soon">
+    <td>Soon</td>
+    <td>Submission date during the nearest 6 days.</td>
+  </tr>
+  <tr class="submit_later">
+    <td>Later</td>
+    <td>Submission date is greater than 6 days.</td>
+  </tr>
+  <tr class="submit_closed">
+    <td>Closed</td>
+    <td>The group is closed and uploaded to creditor, submission date is in the past.</td>
+  </tr>
+</table>
+
 {literal}
 <style>
-  tr.submit_missed {background-color:#000000; color:#FA583F;}
-  tr.submit_urgently {background-color:#FA583F;}
-  tr.submit_soon {background-color:#FAB83F;}
-  tr.submit_closed {background-color:#f0f8ff;}
+  tr.submit_missed {color: #EE0000;}
+  tr.submit_urgently {color: #ac6700;}
+  tr.submit_soon {color: #0165FF;}
+  tr.submit_later {color: #008300;}
+  tr.submit_closed {color: inherit;}
 </style>
 {/literal}
 


### PR DESCRIPTION
Hi @systopia,

We had problem with understanding meaning of colours, especially without any legend. So we decided to create own colours based on logic in code. First of all In this commit colours were moved from background to font. Second, on bottom of page is presented legend.

In examples below there aren't all cases.

What do you think?

**Before active:**
![sepa-before-active](https://cloud.githubusercontent.com/assets/8309610/13429089/c6b3bce8-dfbe-11e5-9e0e-6ab2305935ce.png)

**Before closed**
![sepa-before-closed](https://cloud.githubusercontent.com/assets/8309610/13429098/ce31cd0c-dfbe-11e5-9f21-0e3e0620ff68.png)

**After active**
![sepa-after-active](https://cloud.githubusercontent.com/assets/8309610/13429113/de495a20-dfbe-11e5-99b5-05e04da6bbd4.png)

**After closed**
![sepa-after-closed](https://cloud.githubusercontent.com/assets/8309610/13429116/e45bf242-dfbe-11e5-8c64-33c906da2cea.png)

