### PR TITLE
Add additional conditions used for generate file which depends on file format

### DIFF
--- a/CRM/Sepa/Logic/Format.php
+++ b/CRM/Sepa/Logic/Format.php
@@ -5,10 +5,11 @@ abstract class CRM_Sepa_Logic_Format {
   /** @var string Charset used in output files. */
   public static $out_charset = 'UTF-8';
 
-
   /** @var array Settings per format */
   public static $settings = array();
 
+  /** @var string Additional conditions used for generateXML */
+  public static $generatexml_sql_where = '';
 
   /**
    * Load class based on format name.

--- a/formats/citibankpl/Format.php
+++ b/formats/citibankpl/Format.php
@@ -4,6 +4,9 @@ class CRM_Sepa_Logic_Format_citibankpl extends CRM_Sepa_Logic_Format {
 
   public static $out_charset = 'WINDOWS-1250';
 
+  /** @var string Only accepted (3) or active (5) mandates should be processed */
+  public static $generatexml_sql_where = ' AND mandate.bank_status IN (3, 5)';
+
   public function improveContent($content) {
     return preg_replace('~(*BSR_ANYCRLF)\R~', "\r\n", $content);
   }


### PR DESCRIPTION
PR linked with #397 

This feature is transparent for standard SEPA format because of default value of condition is empty.

Second commit https://github.com/Project60/org.project60.sepa/commit/4262f4a21b1ef487274b64d481fad9d3772eb1bf sets condition for CitiBank format. Keep in mind that we use this format always with extension [Sepa Mandate Batch](https://bitbucket.org/caltha/pl.infozmiana.sepamandatebatch), which alter appropriate field (bank_status).
