### PR TITLE
Fix #472 invalid SQL query

### DIFF
--- a/CRM/Sepa/Page/CreateMandate.php
+++ b/CRM/Sepa/Page/CreateMandate.php
@@ -236,8 +236,9 @@ class CRM_Sepa_Page_CreateMandate extends CRM_Core_Page {
 
     // look up account in other SEPA mandates
     $known_accounts = array();
-    $query_sql = "SELECT DISTINCT iban, bic FROM civicrm_sdd_mandate WHERE contact_id=$contact_id ORDER BY creation_date DESC;";
-    $old_mandates = CRM_Core_DAO::executeQuery($query_sql);
+    $query_sql = "SELECT DISTINCT iban, bic FROM civicrm_sdd_mandate WHERE contact_id=%1";
+    $query_params = array('1' => array($contact_id, 'Integer'));
+    $old_mandates = CRM_Core_DAO::executeQuery($query_sql, $query_params);
     while ($old_mandates->fetch()) {
       $value = $old_mandates->iban.'/'.$old_mandates->bic;
       array_push($known_accounts,


### PR DESCRIPTION
Rather than adding the order field to the select clause as suggested in the issue, I simply removed the order clause since it is not used nor any other field from the mandate.

I also parameterised the query, as the contact id comes from a GET parameters in some scenarios, so it is prone to SQL injection.