### PR TITLE
Small fix php

### DIFF
--- a/templates/CRM/Sepa/Page/DashBoard.tpl
+++ b/templates/CRM/Sepa/Page/DashBoard.tpl
@@ -105,7 +105,7 @@
           {/if}
         {/if}
       {/if}
-      {if $can_delete eq yes}
+      {if $can_delete eq "yes"}
       <a href="{crmURL p="civicrm/sepa/deletegroup" q="group_id=$group_id"}" class="button button_view">{ts domain="org.project60.sepa"}Delete{/ts}</a>
       {/if}
     </td>

--- a/templates/CRM/Sepa/Page/DashBoard.tpl
+++ b/templates/CRM/Sepa/Page/DashBoard.tpl
@@ -105,7 +105,7 @@
           {/if}
         {/if}
       {/if}
-      {if $can_delete eq "yes"}
+      {if $can_delete}
       <a href="{crmURL p="civicrm/sepa/deletegroup" q="group_id=$group_id"}" class="button button_view">{ts domain="org.project60.sepa"}Delete{/ts}</a>
       {/if}
     </td>


### PR DESCRIPTION
Is needed to suppress `Warning: Use of undefined constant yes - assumed 'yes' (this will throw an Error in a future version of PHP)`