### PR TITLE
Fix creditor being reset when closing groups

### DIFF
--- a/CRM/Sepa/BAO/SEPAMandate.php
+++ b/CRM/Sepa/BAO/SEPAMandate.php
@@ -48,7 +48,7 @@ class CRM_Sepa_BAO_SEPAMandate extends CRM_Sepa_DAO_SEPAMandate {
     if (empty($params['id'])) {
       CRM_Utils_SepaCustomisationHooks::create_mandate($params);
 
-      if (empty($params['reference'])) {
+      if (empty($params['reference']) && !empty($params['creditor_id'])) {
         // If no mandate reference was supplied by the caller nor the customisation hook, create a nice default one.
         $creditor = civicrm_api3 ('SepaCreditor', 'getsingle', array ('id' => $params['creditor_id'], 'return' => 'mandate_prefix'));
         $dao = new CRM_Core_DAO();

--- a/api/v3/SepaMandate.php
+++ b/api/v3/SepaMandate.php
@@ -393,10 +393,11 @@ function civicrm_api3_sepa_mandate_get($params) {
 /**
  * HELPER FUNCTION
  *
- * will add the default creditor_id if no creditor_id is given, and the default creditor is valid
+ * will add the default creditor_id if no id and creditor_id is given, and the
+ * default creditor is valid
  */
 function _civicrm_api3_sepa_mandate_adddefaultcreditor(&$params) {
-  if (empty($params['creditor_id'])) {
+  if (empty($params['id']) && empty($params['creditor_id'])) {
     $default_creditor = CRM_Sepa_Logic_Settings::defaultCreditor();
     if ($default_creditor != NULL) {
       $params['creditor_id'] = $default_creditor->id;


### PR DESCRIPTION
When CiviSEPA closes transaction groups of type OOF or FRST, it updates the mandate status to SENT or RCUR respectively. In environments with multiple SEPA creditors, because the API does not check whether it is creating a new mandate or updating an existing one, this update causes the creditor to be set to the default creditor.

Fixes #505