### PR TITLE
Change PSP BIC handling in form and during validation

### DIFF
--- a/CRM/Sepa/Logic/Verification.php
+++ b/CRM/Sepa/Logic/Verification.php
@@ -203,7 +203,7 @@ class CRM_Sepa_Logic_Verification {
 
       default:
       case 'PSP':
-        if (preg_match("/^[a-zA-Z0-9_\/\-=+]{1,11}$/", $bic)) {
+        if (preg_match("/^[a-zA-Z0-9_\/\-=+]{1,25}$/", $bic)) {
           return NULL;
         } else {
           return E::ts("PSP/BIC is not correct");

--- a/js/CreateMandate.js
+++ b/js/CreateMandate.js
@@ -200,19 +200,18 @@ cj(document).ready(function() {
             .val(CRM.vars.p60sdd.creditor_data[creditor_id]['currency'])
             .fadeOut(50).fadeIn(50);
 
-        // if creditor type is not SEPA (or empty): hide bic
+        // if creditor type is not SEPA (or empty): rename bic/iban
         if (!('creditor_type' in CRM.vars.p60sdd.creditor_data[creditor_id])
            || CRM.vars.p60sdd.creditor_data[creditor_id]['creditor_type'] == 'SEPA') {
             // this is a SEPA creditor
-            sdd_getF('bic').parent().parent().show(100);
+            sdd_getF('bic').attr('placeholder', 'required');
+            cj("#sdd-create-mandate").find("label[for=bic]").contents().first()[0].textContent = ts("BIC", {'domain': 'org.project60.sepa'});
             cj("#sdd-create-mandate").find("label[for=iban]").contents().first()[0].textContent = ts("IBAN", {'domain': 'org.project60.sepa'});
 
         } else {
             // this is NOT a SEPA creditor
-            sdd_getF('bic')
-                .val('')
-                .parent().parent().hide(100);
-
+            sdd_getF('bic').attr('placeholder', '');
+            cj("#sdd-create-mandate").find("label[for=bic]").contents().first()[0].textContent = ts("Account Name", {'domain': 'org.project60.sepa'});
             cj("#sdd-create-mandate").find("label[for=iban]").contents().first()[0].textContent = ts("Account Reference", {'domain': 'org.project60.sepa'});
         }
 


### PR DESCRIPTION
With https://github.com/bjendres/de.systopia.pspsepa/pull/6, `de.systopia.pspsepa` uses the BIC field to store (merchant) account names.

To support this in CiviSEPA, this changes the mandate form to stop hiding the BIC field for PSP creditors and renames the field instead. This also alters the BIC format check for PSP creditors to allow values up to 25 characters.