### PR TITLE
Fix inconsistent formatting and validation of IBAN/BIC

### DIFF
--- a/CRM/Sepa/Form/CreateMandate.php
+++ b/CRM/Sepa/Form/CreateMandate.php
@@ -343,22 +343,28 @@ class CRM_Sepa_Form_CreateMandate extends CRM_Core_Form {
     $creditor_mode = empty($creditor['creditor_type']) ? 'SEPA' : $creditor['creditor_type'];
 
     // validate IBAN
-    if ($creditor_mode == 'SEPA') {
-      $iban_error = CRM_Sepa_Logic_Verification::verifyIBAN($this->_submitValues['iban']);
-    } else {
-      $iban_error = CRM_Sepa_Logic_Verification::verifyIBAN($this->_submitValues['iban'], $creditor_mode);
-    }
+    $iban_error = CRM_Sepa_Logic_Verification::verifyIBAN(
+      CRM_Sepa_Logic_Verification::formatIBAN(
+        $this->_submitValues['iban'],
+        $creditor_mode
+      ),
+      $creditor_mode
+    );
     if ($iban_error) {
       $this->_errors['iban'] = $iban_error;
     }
 
     // validate BIC
-    if ($creditor_mode == 'SEPA') {
-      if (empty($this->_submitValues['bic'])) {
-        $bic_error = E::ts("BIC is required");
-      } else {
-        $bic_error = CRM_Sepa_Logic_Verification::verifyBIC($this->_submitValues['bic']);
-      }
+    if ($creditor_mode == 'SEPA' && empty($this->_submitValues['bic'])) {
+      $bic_error = E::ts("BIC is required");
+    } else {
+      $bic_error = CRM_Sepa_Logic_Verification::verifyBIC(
+        CRM_Sepa_Logic_Verification::formatBIC(
+          $this->_submitValues['bic'],
+          $creditor_mode
+        ),
+        $creditor_mode
+      );
     }
     if ($bic_error) {
       $this->_errors['bic'] = $bic_error;

--- a/CRM/Sepa/Logic/Verification.php
+++ b/CRM/Sepa/Logic/Verification.php
@@ -35,12 +35,34 @@ class CRM_Sepa_Logic_Verification {
         $iban = trim($iban);
         $iban = strtoupper($iban);
         $iban = str_replace(' ', '', $iban);
-        return $iban;
+        break;
 
-      default:
       case 'PSP':
-        return trim($iban);
+        $iban = trim($iban);
+        break;
     }
+    return $iban;
+  }
+
+  /**
+   * Format the given BIC
+   *
+   * @param $bic
+   * @param string $type
+   *
+   * @return string formatted BIC
+   */
+  public static function formatBIC($bic, $type = 'SEPA') {
+    switch ($type) {
+      case 'SEPA':
+        $bic = strtoupper($bic);
+        break;
+
+      case 'PSP':
+        $bic = trim($bic);
+        break;
+    }
+    return $bic;
   }
 
 
@@ -203,7 +225,7 @@ class CRM_Sepa_Logic_Verification {
 
       default:
       case 'PSP':
-        if (preg_match("/^[a-zA-Z0-9_\/\-=+]{1,25}$/", $bic)) {
+        if (preg_match("/^[a-zA-Z0-9_\/\-=+]{0,25}$/", $bic)) {
           return NULL;
         } else {
           return E::ts("PSP/BIC is not correct");

--- a/CRM/Sepa/Page/CreateMandate.php
+++ b/CRM/Sepa/Page/CreateMandate.php
@@ -411,7 +411,7 @@ class CRM_Sepa_Page_CreateMandate extends CRM_Core_Page {
     if (!isset($_REQUEST['bic'])) {
       $errors['bic'] = sprintf(ts("'%s' is a required field.", array('domain' => 'org.project60.sepa')), "BIC");
     } else {
-      $_REQUEST['bic'] = strtoupper($_REQUEST['bic']);
+      $_REQUEST['bic'] = CRM_Sepa_Logic_Verification::formatBIC($_REQUEST['bic'], $creditor['creditor_type']);
       if (strlen($_REQUEST['bic']) == 0) {
         $errors['bic'] = sprintf(ts("'%s' is a required field.", array('domain' => 'org.project60.sepa')), "BIC");
       } else {
@@ -426,6 +426,7 @@ class CRM_Sepa_Page_CreateMandate extends CRM_Core_Page {
     if (!isset($_REQUEST['iban'])) {
       $errors['iban'] = sprintf(ts("'%s' is a required field.", array('domain' => 'org.project60.sepa')), "IBAN");
     } else {
+      $_REQUEST['iban'] = CRM_Sepa_Logic_Verification::formatIBAN($_REQUEST['iban'], $creditor['creditor_type']);
       if (strlen($_REQUEST['iban']) == 0) {
         $errors['iban'] = sprintf(ts("'%s' is a required field.", array('domain' => 'org.project60.sepa')), "IBAN");
       } else {


### PR DESCRIPTION
This fixes some inconsistencies in the way IBANs and BICs are formatted and validated in different components. The main issue was that IBANs for PSP creditors would be formatted according to SEPA/IBAN logic (i.e. uppercase, remove spaces), which causes issues for case-sensitive PSPs. Instead, this is now only applied for SEPA creditors.

The IBAN/BIC formatting was moved to a central function to DRY up the code. The formatting is now also applied consistently e.g. in the new mandate form, where previously a lower-case IBAN would've been rejected as invalid.

This also contains some whitespace cleanup that my IDE seems to insist on.