### PR TITLE
Fix PSP token format validation being too strict

### DIFF
--- a/CRM/Sepa/Logic/Verification.php
+++ b/CRM/Sepa/Logic/Verification.php
@@ -91,7 +91,8 @@ class CRM_Sepa_Logic_Verification {
 
       default:
       case 'PSP':
-        if (!preg_match("#^[a-zA-Z0-9_\/\-=+]+$#", $iban)) {
+        // anything that's a string and not empty is fine
+        if (empty($iban) || !is_string($iban)) {
           return E::ts("Invalid PSP Code");
         }
     }


### PR DESCRIPTION
PSP tokens have practically no format requirements, so we now accept anything that's a string and not empty.

Reference: GP-3505