### PR TITLE
Change BIC-less pain.008.001.02 format to never set BIC

### DIFF
--- a/resources/formats_option_group.json
+++ b/resources/formats_option_group.json
@@ -104,7 +104,7 @@
     {
       "_lookup": ["name"],
       "_translate": ["label"],
-      "label": "pain.008.001.02 with alternative DbtrAgt ID",
+      "label": "pain.008.001.02 without BIC",
       "name": "pain_008_001_02_OTHERID",
       "filter": "0",
       "is_reserved": "1",

--- a/templates/Sepa/Formats/pain_008_001_02_OTHERID/transaction-details.tpl
+++ b/templates/Sepa/Formats/pain_008_001_02_OTHERID/transaction-details.tpl
@@ -57,7 +57,7 @@
         <DbtrAgt>
           <FinInstnId>
             <Other>
-              <Identification>{$contribution.bic}</Identification>
+              <Identification>NOTPROVIDED</Identification>
             </Other>
           </FinInstnId>
         </DbtrAgt>


### PR DESCRIPTION
This changes the alternative pain.008.001.02 format to always set the "no bic" value to NOTPROVIDED, rather than using the stored BIC.

To make the intent more clear, this also renames the format to "pain.008.001.02 without BIC".