### PR TITLE
Fix wrong tags being used in BIC-less pain.008.001.02

### DIFF
--- a/templates/Sepa/Formats/pain_008_001_02_OTHERID/transaction-details.tpl
+++ b/templates/Sepa/Formats/pain_008_001_02_OTHERID/transaction-details.tpl
@@ -56,9 +56,9 @@
         </DrctDbtTx>
         <DbtrAgt>
           <FinInstnId>
-            <Other>
-              <Identification>NOTPROVIDED</Identification>
-            </Other>
+            <Othr>
+              <Id>NOTPROVIDED</Id>
+            </Othr>
           </FinInstnId>
         </DbtrAgt>
         <Dbtr>


### PR DESCRIPTION
This replaces `<Other>` and `<Identification>` with the correct tags `<Othr>` and `<Id>`.