### PR TITLE
Fix call to undefined function strotime

### DIFF
--- a/CRM/Sepa/Logic/Batching.php
+++ b/CRM/Sepa/Logic/Batching.php
@@ -589,7 +589,7 @@ class CRM_Sepa_Logic_Batching {
       return NULL;
     }
     // ..or the cancel_date
-    if (!empty($rcontribution['cancel_date']) && strtotime($rcontribution['cancel_date']) < strotime($next_date)) {
+    if (!empty($rcontribution['cancel_date']) && strtotime($rcontribution['cancel_date']) < strtotime($next_date)) {
       return NULL;
     }
 


### PR DESCRIPTION
This fixes a typo (`strotime` instead of `strtotime`).

Note: I didn't do any testing on this, just noticed this when it broke a unit tests in de.systopia.contract.