### PR TITLE
Find existing contributions when the payment instrument of the mandate differs

### DIFF
--- a/CRM/Sepa/Logic/Batching.php
+++ b/CRM/Sepa/Logic/Batching.php
@@ -184,7 +184,7 @@ class CRM_Sepa_Logic_Batching {
               "contribution_status_id"              => $mandate['rc_contribution_status_id'],
               "campaign_id"                         => $mandate['rc_campaign_id'],
               "is_test"                             => $mandate['rc_is_test'],
-              "payment_instrument_id"               => $payment_instrument_id,
+              "payment_instrument_id"               => $mandate['rc_payment_instrument_id'],
             );
           $contribution = civicrm_api('Contribution', 'create', $contribution_data);
           if (empty($contribution['is_error'])) {

--- a/api/v3/SepaMandate.php
+++ b/api/v3/SepaMandate.php
@@ -108,12 +108,15 @@ function civicrm_api3_sepa_mandate_createfull($params) {
     if ($params['type']=='RCUR') {
     	$contribution_entity = 'ContributionRecur';
 	    $contribution_table  = 'civicrm_contribution_recur';
-      	$create_contribution['payment_instrument_id'] = (int) CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'RCUR');
-      	if (empty($create_contribution['status']))
-      		$create_contribution['status'] = 'FRST'; // set default status
-      	if (empty($create_contribution['is_pay_later']))
-      		$create_contribution['is_pay_later'] = 1; // set default pay_later
-
+	    if (!isset($create_contribution['payment_instrument_id'])) {
+        $create_contribution['payment_instrument_id'] = (int) CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'RCUR');
+      }
+      if (empty($create_contribution['status'])) {
+        $create_contribution['status'] = 'FRST'; // set default status
+      }
+      if (empty($create_contribution['is_pay_later'])) {
+        $create_contribution['is_pay_later'] = 1; // set default pay_later
+      }
     } elseif ($params['type']=='OOFF') {
 	 	$contribution_entity = 'Contribution';
 	    $contribution_table  = 'civicrm_contribution';


### PR DESCRIPTION
**Description**

I have a use case where we use CiviSepa for Vipps Recurring (a norwegian payment system). 
We have created mandates with the payment instrument Vipps Recur instead of Sepa DD Recurring Transaction.
This is causing two kind of troubles:
* Contributions are created multiple times because the existing contribution could not be found because those are not paid with Vipps Recur 
* Or they are removed from existing groups. 

**Previous**

The Sepa code was looking for existing contribution for a mandate based on the payment instrument Sepa DD Recurring Transaction

**After**

* Looking up existing contributions is done based on the payment instrument of the mandate.
* I also have added a possibility to set a different payment instrument in the `CiviSepaMandate.Createfull` api
* And the contributions created by Sepa will get the payment instrument from the mandate

**Comment**
When the status is FRST we stil use the `Sepa DD First Transaction` as a payment instrument.
