### PR TITLE
Issue #586: possible to edit the cycle day of an mandate

### DIFF
--- a/CRM/Sepa/BAO/SEPAMandate.php
+++ b/CRM/Sepa/BAO/SEPAMandate.php
@@ -473,6 +473,7 @@ class CRM_Sepa_BAO_SEPAMandate extends CRM_Sepa_DAO_SEPAMandate {
    *  - amount
    *  - campaign_id
    *  - financial type
+   *  - cycle_day
    *
    * Changes will take effect out to all future contributions,
    *  including already created ones in status 'Pending'
@@ -568,6 +569,16 @@ class CRM_Sepa_BAO_SEPAMandate extends CRM_Sepa_DAO_SEPAMandate {
               3 => $new_campaign['title'],
               4 => $changes['campaign_id'],
               'domain' => 'org.project60.sepa'));
+    }
+
+    // CYCLE DAY CHANGE
+    if (!empty($changes['cycle_day']) && $changes['cycle_day'] != $contribution_rcur['cycle_day']) {
+      $contribution_changes['cycle_day'] = $changes['cycle_day'];
+      $changes_subjects[] = ts("Cycle day changed", array('domain' => 'org.project60.sepa'));
+      $changes_details[] = ts("Cycle day changed from '%1' to '%2'.",
+        array(1 => $contribution_rcur['cycle_day'],
+          2 => $changes['cycle_day'],
+          'domain' => 'org.project60.sepa'));
     }
 
     if (!empty($contribution_changes)) try {

--- a/CRM/Sepa/Page/EditMandate.php
+++ b/CRM/Sepa/Page/EditMandate.php
@@ -52,7 +52,8 @@ class CRM_Sepa_Page_EditMandate extends CRM_Core_Page {
 
       } else if ($_REQUEST['action']=='adjustamount') {
         $this->adjustAmount($mandate_id);
-
+      } else if ($_REQUEST['action']=='changecyleday') {
+        $this->changecyleday($mandate_id);
       } else {
         CRM_Core_Session::setStatus(sprintf(ts("Unkown action '%s'. Ignored.", array('domain' => 'org.project60.sepa')), $_REQUEST['action']), ts('Error', array('domain' => 'org.project60.sepa')), 'error');
       }
@@ -100,12 +101,14 @@ class CRM_Sepa_Page_EditMandate extends CRM_Core_Page {
     }
 
     // load the creditor
+    $cycle_days = [];
     if (!empty($mandate['creditor_id'])) {
       $creditor = civicrm_api("SepaCreditor", "getsingle", array('id'=>$mandate['creditor_id'], 'version'=>3));
       if (!empty($creditor['is_error'])) {
         CRM_Core_Session::setStatus(sprintf(ts("Cannot read creditor [%s]. Error was: '%s'", array('domain' => 'org.project60.sepa')), $mandate['creditor_id'], $creditor['error_message']), ts('Error', array('domain' => 'org.project60.sepa')), 'error');
       } else {
         $mandate['creditor_name'] = $creditor['label'];
+        $cycle_days = CRM_Sepa_Logic_Settings::getListSetting("cycledays", range(1, 28), $creditor['id']);
       }
     }
 
@@ -137,6 +140,7 @@ class CRM_Sepa_Page_EditMandate extends CRM_Core_Page {
       $contribution['link']      = CRM_Utils_System::url('civicrm/contact/view/contributionrecur', "&reset=1&id=".$contribution['id']."&cid=".$contact2['id']);
       $contribution['currency']  = $contribution['currency'];
       $contribution['cycle']     = CRM_Utils_SepaOptionGroupTools::getFrequencyText($contribution['frequency_interval'], $contribution['frequency_unit'], true);
+      $contribution['cycle_day_raw'] = $contribution['cycle_day'];
       $contribution['cycle_day'] = CRM_Sepa_Logic_Batching::getCycleDay($contribution, $mandate['creditor_id']);
       if (isset($contribution['next_sched_contribution_date'])) {
         $contribution['next_sched_contribution_date'] = substr($contribution['next_sched_contribution_date'], 0, 10); // the date is enough
@@ -182,6 +186,7 @@ class CRM_Sepa_Page_EditMandate extends CRM_Core_Page {
     $this->assign('can_delete', CRM_Core_Permission::check('delete sepa groups'));
     $this->assign('can_modify', CRM_Sepa_Logic_Settings::getSetting('allow_mandate_modification'));
     $this->assign('sepa_templates', $tpl_ids);
+    $this->assign('cycle_days', $cycle_days);
 
     parent::run();
   }
@@ -294,6 +299,18 @@ class CRM_Sepa_Page_EditMandate extends CRM_Core_Page {
         }
       } else {
         CRM_Core_Session::setStatus(sprintf(ts("Invalid amount. Mandate not modified.", array('domain' => 'org.project60.sepa'))), ts('Error', array('domain' => 'org.project60.sepa')), 'error');
+      }
+    } else {
+      CRM_Core_Session::setStatus(sprintf(ts("Modifying an existing mandate is currently not allowed. You can change this on the SEPA settings page.", array('domain' => 'org.project60.sepa'))), ts('Error', array('domain' => 'org.project60.sepa')), 'error');
+    }
+  }
+
+  function changecyleday($mandate_id) {
+    if (CRM_Sepa_Logic_Settings::getSetting('allow_mandate_modification')) {
+      $new_cycle_day = $_REQUEST['new_cycle_day'];
+      $statuses = CRM_Sepa_BAO_SEPAMandate::modifyMandate($mandate_id, ['cycle_day' => $new_cycle_day]);
+      foreach($statuses as $status) {
+        CRM_Core_Session::setStatus($status, '', 'info');
       }
     } else {
       CRM_Core_Session::setStatus(sprintf(ts("Modifying an existing mandate is currently not allowed. You can change this on the SEPA settings page.", array('domain' => 'org.project60.sepa'))), ts('Error', array('domain' => 'org.project60.sepa')), 'error');

--- a/templates/CRM/Sepa/Page/EditMandate.hlp
+++ b/templates/CRM/Sepa/Page/EditMandate.hlp
@@ -19,3 +19,6 @@
     <p>{ts domain="org.project60.sepa"}The default template can be found and edited at "Communications" -> "Message Templates" -> "System Workflow Messages"{/ts}</p>
     <p>{ts domain="org.project60.sepa"}The templates listed here are all user templates that begin with the prefix 'SEPA'.{/ts}</p>
 {/htxt}
+{htxt id='id-change-cycleday-help'}
+    <p>{ts domain="org.project60.sepa"}When you change the cycle day be aware that this influences when the money is collected.{/ts}</p>
+{/htxt}

--- a/templates/CRM/Sepa/Page/EditMandate.hlp
+++ b/templates/CRM/Sepa/Page/EditMandate.hlp
@@ -20,5 +20,5 @@
     <p>{ts domain="org.project60.sepa"}The templates listed here are all user templates that begin with the prefix 'SEPA'.{/ts}</p>
 {/htxt}
 {htxt id='id-change-cycleday-help'}
-    <p>{ts domain="org.project60.sepa"}When you change the cycle day be aware that this influences when the money is collected.{/ts}</p>
+    <p>{ts domain="org.project60.sepa"}When you change the cycle day be aware that you might end up collecting twice in the same month, or miss a collection altogether.{/ts}</p>
 {/htxt}

--- a/templates/CRM/Sepa/Page/EditMandate.tpl
+++ b/templates/CRM/Sepa/Page/EditMandate.tpl
@@ -110,7 +110,7 @@
             {if $can_modify}{if $contribution.cycle_day}{if $sepa.status eq 'FRST' or $sepa.status eq 'RCUR' or $sepa.status eq 'INIT'}<tr>
               <td class="label" style="vertical-align: middle;"><a class="button" onclick="mandate_action_change_cycle_day();">{ts domain="org.project60.sepa"}Change Cycle Day{/ts}</td>
               <td>
-                  {ts domain="org.project60.sepa"}New cycle day:{/ts}&nbsp;
+                  {ts domain="org.project60.sepa"}New cycle day:{/ts}<a id='template_help' onclick='CRM.help("{ts domain="org.project60.sepa"}Cyle Day{/ts}", {literal}{"id":"id-change-cycleday-help","file":"CRM\/Sepa\/Page\/EditMandate"}{/literal}); return false;' href="#" title="{ts domain="org.project60.sepa"}Help{/ts}" class="helpicon">&nbsp;</a>&nbsp;
                   <select name="new_cycle_day" id="new_cycle_day" class="crm-form-select">
                     {foreach from=$cycle_days item=cycle_day_label key=cycle_day_value}
                       <option value="{$cycle_day_value}" {if ($cycle_day_value == $contribution.cycle_day_raw)}selected="selected"{/if}>{$cycle_day_label}</option>

--- a/templates/CRM/Sepa/Page/EditMandate.tpl
+++ b/templates/CRM/Sepa/Page/EditMandate.tpl
@@ -48,7 +48,9 @@
 	            <tr><td class="label">{ts domain="org.project60.sepa"}Create Date{/ts}</td><td>{$contribution.create_date}</td></tr>
 	            <tr><td class="label">{ts domain="org.project60.sepa"}Last Modified{/ts}</td><td>{$contribution.modified_date}</td></tr>
 	            <tr><td class="label">{ts domain="org.project60.sepa"}Frequency{/ts}</td><td>{$contribution.cycle}</td></tr>
-	            <tr><td class="label">{ts domain="org.project60.sepa"}Collection Day{/ts}</td><td>{$contribution.cycle_day}</td></tr>
+	            <tr><td class="label">{ts domain="org.project60.sepa"}Collection Day{/ts}</td><td>{$contribution.cycle_day}
+
+              </td></tr>
                 <tr><td class="label">{ts domain="org.project60.sepa"}Start Date{/ts}</td><td>{$contribution.start_date}</td></tr>
                 <tr><td class="label">{ts domain="org.project60.sepa"}End Date{/ts}</td><td>{$contribution.end_date}</td></tr>
                 <tr><td class="label">{ts domain="org.project60.sepa"}Next Collection{/ts}</td><td>{$contribution.next_sched_contribution_date}</td></tr>
@@ -106,6 +108,18 @@
             </tr>{/if}{/if}
 
             {if $can_modify}{if $contribution.cycle_day}{if $sepa.status eq 'FRST' or $sepa.status eq 'RCUR' or $sepa.status eq 'INIT'}<tr>
+              <td class="label" style="vertical-align: middle;"><a class="button" onclick="mandate_action_change_cycle_day();">{ts domain="org.project60.sepa"}Change Cycle Day{/ts}</td>
+              <td>
+                  {ts domain="org.project60.sepa"}New cycle day:{/ts}&nbsp;
+                  <select name="new_cycle_day" id="new_cycle_day" class="crm-form-select">
+                    {foreach from=$cycle_days item=cycle_day_label key=cycle_day_value}
+                      <option value="{$cycle_day_value}" {if ($cycle_day_value == $contribution.cycle_day_raw)}selected="selected"{/if}>{$cycle_day_label}</option>
+                    {/foreach}
+                  </select>
+              </td>
+            </tr>{/if}{/if}{/if}
+
+            {if $can_modify}{if $contribution.cycle_day}{if $sepa.status eq 'FRST' or $sepa.status eq 'RCUR' or $sepa.status eq 'INIT'}<tr>
                 <td class="label" style="vertical-align: middle;"><a class="button" onclick="mandate_action_adjust_amount();">{ts domain="org.project60.sepa"}Adjust Amount{/ts}</td>
                 <td>
                     {ts domain="org.project60.sepa"}Change amount to:{/ts}&nbsp;<input type="text" name="adjust_amount" id="adjust_amount" size="12" value="{$contribution.amount}" />&nbsp;EUR
@@ -158,6 +172,11 @@ function mandate_action_delete() {
 function mandate_action_adjust_amount() {
     cj("#mandate_action_value").val('adjustamount');
     cj("#sepa_action_form").submit();
+}
+
+function mandate_action_change_cycle_day() {
+  cj("#mandate_action_value").val('changecyleday');
+  cj("#sepa_action_form").submit();
 }
 
 function mandate_action_cancel() {


### PR DESCRIPTION
**Before**

Not possible to change the cycle day of an existing mandate

**After**

When Modify of Mandate is enabled and you edit an existing mandate you can also change the cycle day.

See #586 
