### PR TITLE
GP-4897 Fix array to string conversion for default PIs

### DIFF
--- a/CRM/Sepa/BAO/SEPACreditor.php
+++ b/CRM/Sepa/BAO/SEPACreditor.php
@@ -41,8 +41,8 @@ class CRM_Sepa_BAO_SEPACreditor extends CRM_Sepa_DAO_SEPACreditor {
     // add default payment instruments for a new creditor if none provided
     if (empty($params['id']) && !isset($params['pi_ooff']) && !isset($params['pi_rcur'])) {
       $default_pis = CRM_Sepa_Logic_PaymentInstruments::getDefaultSEPAPaymentInstruments();
-      $params['pi_ooff'] = $default_pis['ooff_sepa_default'];
-      $params['pi_rcur'] = $default_pis['rcur_sepa_default'];
+      $params['pi_ooff'] = implode(',', $default_pis['ooff_sepa_default']);
+      $params['pi_rcur'] = implode(',', $default_pis['rcur_sepa_default']);
     }
 
     $dao = new CRM_Sepa_DAO_SEPACreditor();


### PR DESCRIPTION
This fixes an array to string conversion issue when default PIs are used. There's some code in `DB_DataObject` that uses these values as strings. Likely not an issue from the UI as it always passes these values as strings.

Noticed this because it was breaking tests in `de.systopia.contract` due to `convertNoticesToExceptions`.