### PR TITLE
Improve installation guide

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -32,11 +32,17 @@ Find more documentation on http://wiki.civicrm.org/confluence/display/CRM/CiviSE
 * membership payments
 * automatic submission to the banks
 
+
 ## Installation
-Use the following steps to install CiviSEPA.
- * **Administer** > **System Settings** > **Extensions**
- * **Add New**
- * Find, download, and install
+
+This extension needs to be installed manually into CiviCRM. It is not (yet) available from the built-in extensions catalog.
+
+First, download an official release archive from the [release page](https://github.com/Project60/org.project60.sepa/releases). Unpack the archive and move the directory `org.project60.sepa` into your extensions directory (e.g., `.../civicrm/ext/`; you can find the exact location in your CiviCRM settings (Administer/System Settings/Directories)).
+
+Next, open the extensions page in the CiviCRM settings (Administer/System Settings/Extensions). Find the extension `SEPA Direct Debit` in the "Extensions" tab and click on "Install". The extension will be set up.
+
+Finally, you will have to update your database scheme. CiviCRM will prompt you to do so in a pop-up. Alternatively, you will find a prompt in the "System Status" in the admin console. Once you updated your database, the extension will be ready for use.
+
 
 ## Customisation
 If you need customised mandate references, exclude certain collection dates, or add a custom transaction message to the collection, you want to create a sepa customization extension implementing the following hooks:


### PR DESCRIPTION
The previous wording was misleading and caused confusion to new users (both of CiviCRM and the extension; see #593 for instance). This commit attempts to refine the wording to help new users install the extension.

Closes #593.