### PR TITLE
Fix composer and maildev issue in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,10 @@
 version: 2.1
 commands:
+  setup:
+    description: "Setup environment"
+    steps:
+      - run: |
+          composer self-update --1
   install_civicrm:
     description: "Install CiviCRM"
     parameters:
@@ -110,11 +115,14 @@ executors:
         name: mysql
         environment:
           MYSQL_ROOT_PASSWORD: buildkit
+      - image: maildev/maildev
+        name: maildev
 
 jobs:
   build_mysql_5_7:
     executor: civicrm
     steps:
+      - setup
       - checkout
       - run_all
       - run_all:
@@ -141,7 +149,10 @@ jobs:
         name: mysql
         environment:
           MYSQL_ROOT_PASSWORD: buildkit
+      - image: maildev/maildev
+        name: maildev
     steps:
+      - setup
       - checkout
       - run_all
       - run_all:
@@ -168,7 +179,10 @@ jobs:
         name: mysql
         environment:
           MYSQL_ROOT_PASSWORD: buildkit
+      - image: maildev/maildev
+        name: maildev
     steps:
+      - setup
       - checkout
       - run_all
       - run_all:


### PR DESCRIPTION
This fixes some CI issues by forcing composer to use v1 and adding the `maildev` image to work around a problem during Drupal setup.

The `maildev` issue is unrelated to composer, but we've been seeing that one from time to time for other extensions, and it hit me while testing this fix. It usually causes build failures with "Unable to send e-mail. Contact the site administrator if the problem persists." during the `civibuild` run.

Fixes #604