### PR TITLE
Use more reliable method to generate unique mandate reference 

### DIFF
--- a/CRM/Sepa/BAO/SEPAMandate.php
+++ b/CRM/Sepa/BAO/SEPAMandate.php
@@ -71,8 +71,8 @@ class CRM_Sepa_BAO_SEPAMandate extends CRM_Sepa_DAO_SEPAMandate {
         // If no mandate reference was supplied by the caller nor the customisation hook, create a nice default one.
         $dao = new CRM_Core_DAO();
         $database = $dao->database();
-        $next_id = CRM_Core_DAO::singleValueQuery("SELECT auto_increment FROM information_schema.tables WHERE table_schema='$database' and table_name='civicrm_sdd_mandate';");
-        $params['reference'] = $creditor['mandate_prefix'] . '-' . $params['creditor_id'] . '-' . $params['type'] . '-' . date("Y") . '-' . $next_id;
+        $uuid = CRM_Core_DAO::singleValueQuery("SELECT CONV(UUID_SHORT(), 10, 36)");
+        $params['reference'] = $creditor['mandate_prefix'] . '-' . $params['creditor_id'] . '-' . $params['type'] . '-' . date("Y") . '-' . $uuid;
       }
     }
 


### PR DESCRIPTION
Fix for #609

The default reference pattern is going to be longer and use alphanumeric characters. While it would be possible to make it shorter and look like the previous pattern it would require making some guesses on how many mandates have been generated by existing users of the extensions so I didn't follow that path.

MySQL says that `uuid_short` guarantees uniqueness across replicas if it is called less than 16M times per second on average, so I think we should be fine :)