### PR TITLE
fix "group by" queries when sql_mode is `only_full_group_by`

### DIFF
--- a/CRM/Sepa/BAO/SEPATransactionGroup.php
+++ b/CRM/Sepa/BAO/SEPATransactionGroup.php
@@ -105,7 +105,10 @@ class CRM_Sepa_BAO_SEPATransactionGroup extends CRM_Sepa_DAO_SEPATransactionGrou
         AND c.contribution_status_id != 3
         AND mandate.is_enabled = true
       GROUP BY c.id"; //and not cancelled
+
+    CRM_Core_DAO::disableFullGroupByMode();
     $contrib = CRM_Core_DAO::executeQuery($query, $queryParams);
+    CRM_Core_DAO::reenableFullGroupByMode();
 
     setlocale(LC_CTYPE, 'en_US.utf8');
     //dear dear, it might work, but seems to be highly dependant of the system running it, without any way to know what is available, or if the setting was done properly #phpeature

--- a/CRM/Sepa/Page/MandateTab.php
+++ b/CRM/Sepa/Page/MandateTab.php
@@ -44,7 +44,7 @@ class CRM_Sepa_Page_MandateTab extends CRM_Core_Page {
         civicrm_contribution.total_amount  AS total_amount,
         civicrm_contribution.currency      AS currency,
         civicrm_contribution.cancel_reason AS cancel_reason,
-        IF(civicrm_sdd_mandate.status IN ('OOFF'), 'sepa-active', 'sepa-inactive')           
+        IF(civicrm_sdd_mandate.status IN ('OOFF'), 'sepa-active', 'sepa-inactive')
                                            AS class
       FROM civicrm_sdd_mandate
       LEFT JOIN civicrm_contribution   ON civicrm_contribution.id = civicrm_sdd_mandate.entity_id
@@ -105,7 +105,7 @@ class CRM_Sepa_Page_MandateTab extends CRM_Core_Page {
         civicrm_contribution_recur.frequency_unit               AS frequency_unit,
         civicrm_contribution_recur.currency                     AS currency,
         civicrm_contribution_recur.amount                       AS amount,
-        IF(civicrm_sdd_mandate.status IN ('FRST', 'RCUR'), 'sepa-active', 'sepa-inactive')           
+        IF(civicrm_sdd_mandate.status IN ('FRST', 'RCUR'), 'sepa-active', 'sepa-inactive')
                                                                 AS class
       FROM civicrm_sdd_mandate
       LEFT JOIN civicrm_contribution_recur ON civicrm_contribution_recur.id = civicrm_sdd_mandate.entity_id
@@ -124,8 +124,13 @@ class CRM_Sepa_Page_MandateTab extends CRM_Core_Page {
       ORDER BY civicrm_contribution_recur.start_date DESC, civicrm_sdd_mandate.id DESC;";
 
     $mandate_ids = array();
+
+    CRM_Core_DAO::disableFullGroupByMode();
     $rcur_mandates = CRM_Core_DAO::executeQuery($rcur_query,
-      array( 1 => array($contact_id, 'Integer')));
+      array(1 => array($contact_id, 'Integer'))
+    );
+    CRM_Core_DAO::reenableFullGroupByMode();
+
     while ($rcur_mandates->fetch()) {
       $rcur = array(
         'mandate_id'           => $rcur_mandates->mandate_id,
@@ -182,7 +187,11 @@ class CRM_Sepa_Page_MandateTab extends CRM_Core_Page {
           AND civicrm_contribution.id IS NOT NULL
         GROUP BY civicrm_sdd_mandate.id
         ORDER BY civicrm_contribution.receive_date;";
+
+      CRM_Core_DAO::disableFullGroupByMode();
       $fail_query = CRM_Core_DAO::executeQuery($fail_sequence);
+      CRM_Core_DAO::reenableFullGroupByMode();
+
       while ($fail_query->fetch()) {
         if (preg_match("#(?<last_fails>1+)$#", $fail_query->fail_sequence, $match)) {
           $last_sequence = $match['last_fails'];
@@ -202,7 +211,7 @@ class CRM_Sepa_Page_MandateTab extends CRM_Core_Page {
    */
   public static function getMandateCount($contact_id) {
     return CRM_Core_DAO::singleValueQuery("
-        SELECT COUNT(id) FROM civicrm_sdd_mandate 
+        SELECT COUNT(id) FROM civicrm_sdd_mandate
         WHERE contact_id = %1
           AND status IN ('FRST', 'RCUR', 'OOFF', 'INIT');",
             array( 1 => array($contact_id, 'Integer')));

--- a/api/v3/SepaTransactionGroup.php
+++ b/api/v3/SepaTransactionGroup.php
@@ -126,8 +126,9 @@ function civicrm_api3_sepa_transaction_group_getdetail($params) {
     LEFT JOIN civicrm_contribution as contrib on txgroup_contrib.contribution_id = contrib.id
     LEFT JOIN civicrm_sdd_file on sdd_file_id = civicrm_sdd_file.id
     WHERE $where
-    GROUP BY txgroup.id
+    GROUP BY txgroup.id, txgroup.reference, sdd_file_id, txgroup.type, txgroup.collection_date, txgroup.latest_submission_date, txgroup.status_id, txgroup.sdd_creditor_id, civicrm_sdd_file.created_date, contrib.currency, civicrm_sdd_file.reference
     $orderby;";
+
   $dao = CRM_Core_DAO::executeQuery($sql);
   $result= array();
   $total =0;
@@ -264,9 +265,10 @@ function civicrm_api3_sepa_transaction_group_toaccgroup($params) {
   LEFT JOIN civicrm_contribution          AS contribution ON txgroup_contrib.contribution_id = contribution.id
   LEFT JOIN civicrm_entity_financial_trxn AS entity_trxn  ON entity_trxn.entity_id = contribution.id AND entity_trxn.entity_table='civicrm_contribution'
   WHERE txgroup_contrib.txgroup_id = $txgroup_id
-  GROUP BY contribution.id;";
+  GROUP BY contribution.id, entity_trxn.financial_trxn_id, contribution.total_amount;";
 
   $contributions_query = CRM_Core_DAO::executeQuery($contributions_query_sql);
+
   $transactions = array();
   $contributions_missing_transaction = array();
   $total = 0.0;


### PR DESCRIPTION
I try to fix `sql_mode=only_full_group_by` incompatibility.

Where I was quite sure, I added the missing columns in the 'group by'.
Other times I wrapped the query `CRM_Utils_SQL::disableFullGroupByMode()` directives as suggested by @bjendres.

See this issue: [SEPA Mandates: this is incompatible with sql_mode=only_full_group_by](https://github.com/Project60/org.project60.sepa/issues/584).



