### PR TITLE
update hook_civicrm_tabset for 5.57 forward-compat

### DIFF
--- a/sepa.php
+++ b/sepa.php
@@ -561,15 +561,16 @@ function sepa_civicrm_tokenValues(&$values, $cids, $job = null, $tokens = array(
  * Will inject the SepaMandate tab
  */
 function sepa_civicrm_tabset($tabsetName, &$tabs, $context) {
-  if (    $tabsetName == 'civicrm/contact/view'
-       && !empty($context['contact_id'])
-       && CRM_Core_Permission::check('view sepa mandates')) {
+  if ($tabsetName == 'civicrm/contact/view' &&
+    (empty($context['contact_id']) || CRM_Core_Permission::check('view sepa mandates'))
+  ) {
     $tabs[] = [
       'id'     => 'sepa',
       'url'    => CRM_Utils_System::url('civicrm/sepa/tab', "reset=1&snippet=1&force=1&cid={$context['contact_id']}"),
       'title'  => E::ts('SEPA Mandates'),
       'count'  => CRM_Sepa_Page_MandateTab::getMandateCount($context['contact_id']),
-      'weight' => 20
+      'icon'   => 'crm-i fa-bank',
+      'weight' => 20,
     ];
   }
 }


### PR DESCRIPTION
This makes the hook both forward and backward compatible with current and future versions of core and the ContactLayout extension.