### PR TITLE
adds new style token processing

### DIFF
--- a/CRM/Sepa/BAO/SEPAMandate.php
+++ b/CRM/Sepa/BAO/SEPAMandate.php
@@ -895,6 +895,39 @@ class CRM_Sepa_BAO_SEPAMandate extends CRM_Sepa_DAO_SEPAMandate {
     return $mandate_by_rcontribution_id[$recurring_contribution_id];
   }
 
+  public static function getLastMandateOfContact($cid) {
+    if (empty($cid)) {
+      return FALSE;
+    }
+
+    $query = "SELECT contact_id, MAX(id) AS mandate_id FROM civicrm_sdd_mandate WHERE contact_id = $cid GROUP BY contact_id;";
+    $result = CRM_Core_DAO::executeQuery($query);
+    if ($result->fetch()) {
+      // return the mandate
+      return civicrm_api3('SepaMandate', 'getsingle', array('id' => $result->mandate_id));
+    }
+    else {
+      return FALSE;
+    }
+  }
+
+  public static function isContributionMandate($mandate) {
+    if ($mandate['entity_table'] == 'civicrm_contribution') {
+      return TRUE;
+    }
+    else {
+      return FALSE;
+    }
+  }
+
+  public static function isContributionRecurMandate($mandate) {
+    if ($mandate['entity_table'] == 'civicrm_contribution_recur') {
+      return TRUE;
+    }
+    else {
+      return FALSE;
+    }
+  }
 }
 
 

--- a/CRM/Utils/SepaTokens.php
+++ b/CRM/Utils/SepaTokens.php
@@ -2,7 +2,7 @@
 
 use CRM_Sepa_ExtensionUtil as E;
 
-class SepaTokens {
+class CRM_Utils_SepaTokens {
   public static function getTokenList() {
     return [
       'reference'               => E::ts('Reference', ['domain' => 'org.project60.sepa']),

--- a/CRM/Utils/SepaTokens.php
+++ b/CRM/Utils/SepaTokens.php
@@ -1,0 +1,100 @@
+<?php
+
+use CRM_Sepa_ExtensionUtil as E;
+
+class SepaTokens {
+  public static function getTokenList() {
+    return [
+      'reference'               => E::ts('Reference', ['domain' => 'org.project60.sepa']),
+      'source'                  => E::ts('Source', ['domain' => 'org.project60.sepa']),
+      'type'                    => E::ts('Type', ['domain' => 'org.project60.sepa']),
+      'status'                  => E::ts('Status', ['domain' => 'org.project60.sepa']),
+      'date'                    => E::ts('Signature Date (raw)', ['domain' => 'org.project60.sepa']),
+      'date_text'               => E::ts('Signature Date', ['domain' => 'org.project60.sepa']),
+      'account_holder'          => E::ts('Account Holder', ['domain' => 'org.project60.sepa']),
+      'iban'                    => E::ts('IBAN', ['domain' => 'org.project60.sepa']),
+      'iban_anonymised'         => E::ts('IBAN (anonymised)', ['domain' => 'org.project60.sepa']),
+      'bic'                     => E::ts('BIC', ['domain' => 'org.project60.sepa']),
+      'amount'                  => E::ts('Amount (raw)', ['domain' => 'org.project60.sepa']),
+      'amount_text'             => E::ts('Amount', ['domain' => 'org.project60.sepa']),
+      'currency'                => E::ts('Currency', ['domain' => 'org.project60.sepa']),
+      'first_collection'        => E::ts('First Collection Date (raw)', ['domain' => 'org.project60.sepa']),
+      'first_collection_text'   => E::ts('First Collection Date', ['domain' => 'org.project60.sepa']),
+      'cycle_day'               => E::ts('Cycle Day', ['domain' => 'org.project60.sepa']),
+      'frequency_interval'      => E::ts('Interval Multiplier', ['domain' => 'org.project60.sepa']),
+      'frequency_unit'          => E::ts('Interval Unit', ['domain' => 'org.project60.sepa']),
+      'frequency'               => E::ts('Interval', ['domain' => 'org.project60.sepa']),
+    ];
+  }
+
+  public static function fillLastMandateTokenValues($contactId, $prefix, \Civi\Token\TokenRow $tokenRow) {
+    $mandate = CRM_Sepa_BAO_SEPAMandate::getLastMandateOfContact($contactId);
+    if ($mandate) {
+      self::fillLastMandateCommonTokenValues($mandate, $prefix, $tokenRow);
+
+      if (CRM_Sepa_BAO_SEPAMandate::isContributionMandate($mandate)) {
+        self::fillLastMandateContributionTokenValues($mandate, $prefix, $tokenRow);
+      }
+      elseif (CRM_Sepa_BAO_SEPAMandate::isContributionRecurMandate($mandate)) {
+        self::fillLastMandateContributionRecurTokenValues($mandate, $prefix, $tokenRow);
+      }
+    }
+  }
+
+  private static function fillLastMandateCommonTokenValues($mandate, $prefix, \Civi\Token\TokenRow $tokenRow) {
+    // copy the mandate values
+    $tokenRow->tokens($prefix, 'reference',        $mandate['reference']);
+    $tokenRow->tokens($prefix, 'source',           $mandate['source']);
+    $tokenRow->tokens($prefix, 'type',             $mandate['type']);
+    $tokenRow->tokens($prefix, 'status',           $mandate['status']);
+    $tokenRow->tokens($prefix, 'date',             $mandate['date']);
+    //$tokenRow->tokens($prefix, 'account_holder',   $mandate['account_holder']);
+    $tokenRow->tokens($prefix, 'iban',             $mandate['iban']);
+    $tokenRow->tokens($prefix, 'iban_anonymised',  CRM_Sepa_Logic_Verification::anonymiseIBAN($mandate['iban']));
+    $tokenRow->tokens($prefix, 'bic',              $mandate['bic']);
+
+    if (!empty($mandate['date'])) {
+      $tokenRow->tokens($prefix, 'date_text', CRM_Utils_Date::customFormat($mandate['date']));
+    }
+  }
+
+  private static function fillLastMandateContributionTokenValues($mandate, $prefix, \Civi\Token\TokenRow $tokenRow) {
+    $contribution = civicrm_api3('Contribution', 'getsingle', array('id' => $mandate['entity_id']));
+    $tokenRow->tokens($prefix, 'amount',           $contribution['total_amount']);
+    $tokenRow->tokens($prefix, 'currency',         $contribution['currency']);
+    $tokenRow->tokens($prefix, 'amount_text',      CRM_Utils_Money::format($contribution['total_amount'], $contribution['currency']));
+
+    if (!empty($contribution['receive_date'])) {
+      $formattedDate = CRM_Utils_Date::customFormat($contribution['receive_date']);
+      $tokenRow->tokens($prefix, 'first_collection', $formattedDate);
+    }
+  }
+
+  private static function fillLastMandateContributionRecurTokenValues($mandate, $prefix, \Civi\Token\TokenRow $tokenRow) {
+    $rcontribution = civicrm_api3('ContributionRecur', 'getsingle', array('id' => $mandate['entity_id']));
+    $tokenRow->tokens($prefix, 'amount',             $rcontribution['amount']);
+    $tokenRow->tokens($prefix, 'currency',           $rcontribution['currency']);
+    $tokenRow->tokens($prefix, 'amount_text',        CRM_Utils_Money::format($rcontribution['amount'], $rcontribution['currency']));
+    $tokenRow->tokens($prefix, 'cycle_day',          $rcontribution['cycle_day']);
+    $tokenRow->tokens($prefix, 'frequency_interval', $rcontribution['frequency_interval']);
+    $tokenRow->tokens($prefix, 'frequency_unit',     $rcontribution['frequency_unit']);
+    $tokenRow->tokens($prefix, 'frequency',          CRM_Utils_SepaOptionGroupTools::getFrequencyText($rcontribution['frequency_interval'], $rcontribution['frequency_unit'], true));
+
+    // first collection date
+    if (empty($mandate['first_contribution_id'])) {
+      // calculate
+      $calculator = new CRM_Sepa_Logic_NextCollectionDate($mandate['creditor_id']);
+      $firstCollectionDate = $calculator->calculateNextCollectionDate($mandate['entity_id']);
+    }
+    else {
+      // use date of first contribution
+      $fcontribution = civicrm_api3('Contribution', 'getsingle', array('id' => $mandate['first_contribution_id']));
+      $firstCollectionDate = $fcontribution['receive_date'];
+    }
+
+    if (!empty($firstCollectionDate)) {
+      $formattedDate = CRM_Utils_Date::customFormat($firstCollectionDate);
+      $tokenRow->tokens($prefix, 'first_collection', $formattedDate);
+    }
+  }
+}

--- a/CRM/Utils/SepaTokensDeprecated.php
+++ b/CRM/Utils/SepaTokensDeprecated.php
@@ -1,0 +1,74 @@
+<?php
+
+use CRM_Sepa_ExtensionUtil as E;
+
+class SepaTokensDeprecated {
+  public static function getTokenList() {
+    return SepaTokens::getTokenList();
+  }
+
+  public static function fillLastMandateTokenValues($contactId, $prefix, &$values) {
+    $mandate = CRM_Sepa_BAO_SEPAMandate::getLastMandateOfContact($contactId);
+    if (!$mandate) {
+      return;
+    }
+
+    try {
+      // copy the mandate values
+      $values[$contactId]["$prefix.reference"] = $mandate['reference'];
+      $values[$contactId]["$prefix.source"] = $mandate['source'];
+      $values[$contactId]["$prefix.type"] = $mandate['type'];
+      $values[$contactId]["$prefix.status"] = $mandate['status'];
+      $values[$contactId]["$prefix.date"] = $mandate['date'];
+      $values[$contactId]["$prefix.account_holder"] = $mandate['account_holder'];
+      $values[$contactId]["$prefix.iban"] = $mandate['iban'];
+      $values[$contactId]["$prefix.iban_anonymised"] = CRM_Sepa_Logic_Verification::anonymiseIBAN($mandate['iban']);
+      $values[$contactId]["$prefix.bic"] = $mandate['bic'];
+
+      // load and copy the contribution information
+      if ($mandate['entity_table'] == 'civicrm_contribution') {
+        $contribution = civicrm_api3('Contribution', 'getsingle', ['id' => $mandate['entity_id']]);
+        $values[$contactId]["$prefix.amount"] = $contribution['total_amount'];
+        $values[$contactId]["$prefix.currency"] = $contribution['currency'];
+        $values[$contactId]["$prefix.amount_text"] = CRM_Utils_Money::format($contribution['total_amount'], $contribution['currency']);
+        $values[$contactId]["$prefix.first_collection"] = $contribution['receive_date'];
+
+      }
+      elseif ($mandate['entity_table'] == 'civicrm_contribution_recur') {
+        $rcontribution = civicrm_api3('ContributionRecur', 'getsingle', ['id' => $mandate['entity_id']]);
+        $values[$contactId]["$prefix.amount"] = $rcontribution['amount'];
+        $values[$contactId]["$prefix.currency"] = $rcontribution['currency'];
+        $values[$contactId]["$prefix.amount_text"] = CRM_Utils_Money::format($rcontribution['amount'], $rcontribution['currency']);
+        $values[$contactId]["$prefix.cycle_day"] = $rcontribution['cycle_day'];
+        $values[$contactId]["$prefix.frequency_interval"] = $rcontribution['frequency_interval'];
+        $values[$contactId]["$prefix.frequency_unit"] = $rcontribution['frequency_unit'];
+        $values[$contactId]["$prefix.frequency"] = CRM_Utils_SepaOptionGroupTools::getFrequencyText($rcontribution['frequency_interval'], $rcontribution['frequency_unit'], TRUE);
+
+        // first collection date
+        if (empty($mandate['first_contribution_id'])) {
+          // calculate
+          $calculator = new CRM_Sepa_Logic_NextCollectionDate($mandate['creditor_id']);
+          $values[$contactId]["$prefix.first_collection"] = $calculator->calculateNextCollectionDate($mandate['entity_id']);
+
+        }
+        else {
+          // use date of first contribution
+          $fcontribution = civicrm_api3('Contribution', 'getsingle', ['id' => $mandate['first_contribution_id']]);
+          $values[$contactId]["$prefix.first_collection"] = $fcontribution['receive_date'];
+        }
+      }
+
+      // format dates
+      if (!empty($values[$contactId]["$prefix.first_collection"])) {
+        $values[$contactId]["$prefix.first_collection_text"] = CRM_Utils_Date::customFormat($values[$contactId]["$prefix.first_collection"]);
+      }
+      if (!empty($values[$contactId]["$prefix.date"])) {
+        $values[$contactId]["$prefix.date_text"] = CRM_Utils_Date::customFormat($values[$contactId]["$prefix.date"]);
+      }
+    }
+    catch (Exception $e) {
+      // probably just a minor issue, see SEPA-461
+    }
+  }
+
+}

--- a/CRM/Utils/SepaTokensDeprecated.php
+++ b/CRM/Utils/SepaTokensDeprecated.php
@@ -2,9 +2,9 @@
 
 use CRM_Sepa_ExtensionUtil as E;
 
-class SepaTokensDeprecated {
+class CRM_Utils_SepaTokensDeprecated {
   public static function getTokenList() {
-    return SepaTokens::getTokenList();
+    return CRM_Utils_SepaTokens::getTokenList();
   }
 
   public static function fillLastMandateTokenValues($contactId, $prefix, &$values) {

--- a/sepa.php
+++ b/sepa.php
@@ -448,7 +448,7 @@ function sepa_civicrm_tokens(&$tokens) {
   $prefix = ts("Most Recent SEPA Mandate", ['domain' => 'org.project60.sepa']);
   $prefix = str_replace(' ', '_', $prefix); // spaces break newletters, see https://github.com/Project60/org.project60.sepa/issues/419
 
-  $tokenList = SepaTokensDeprecated::getTokenList();
+  $tokenList = CRM_Utils_SepaTokensDeprecated::getTokenList();
   foreach ($tokenList as $token => $tokenDescription) {
     $tokens[$prefix]["$prefix.$token"] = $tokenDescription;
   }
@@ -485,14 +485,14 @@ function sepa_civicrm_tokenValues(&$values, $cids, $job = null, $tokens = [], $c
   if (!in_array($prefix, array_keys($tokens))) return;
 
   foreach ($cids as $cid) {
-    SepaTokensDeprecated::fillLastMandateTokenValues($cid, $prefix, $values);
+    CRM_Utils_SepaTokensDeprecated::fillLastMandateTokenValues($cid, $prefix, $values);
   }
 }
 
 function sepa_register_tokens(\Civi\Token\Event\TokenRegisterEvent $e) {
   $prefix = 'Most_Recent_SEPA_Mandate';
 
-  $tokenList = SepaTokens::getTokenList();
+  $tokenList = CRM_Utils_SepaTokens::getTokenList();
   foreach ($tokenList as $token => $tokenDescription) {
     $e->entity($prefix)->register($token, $tokenDescription);
   }
@@ -504,7 +504,7 @@ function sepa_evaluate_tokens(\Civi\Token\Event\TokenValueEvent $e) {
   foreach ($e->getRows() as $tokenRow) {
     if (!empty($row->context['contactId'])) {
       $row->format('text/html');
-      SepaTokens::fillLastMandateTokenValues($row->context['contactId'], $prefix, $tokenRow);
+      CRM_Utils_SepaTokens::fillLastMandateTokenValues($row->context['contactId'], $prefix, $tokenRow);
     }
   }
 }


### PR DESCRIPTION
I noticed that the Most_Recent_SEPA_Mandate tokens are not replaced anymore in version 5.58.1, because the hooks hook_civicrm_tokens and hook_civicrm_tokenValues are deprecated.

This PR adds the new of processing tokens, while retaining the legacy way. 

See also: https://docs.civicrm.org/dev/en/latest/framework/token/#defining-tokens for more information.

My attempt in this PR is to:
- only touch the token code
- make new token processing and legacy processing as similar as possible
- convert array to [] in the files I changed
- move as much code out of sepa.php
  - 3 methods were added to the BAO SEPAMandate
  - a new helper class SepaTokens was added for the new way of handling tokens
  - a new helper class SepaTokensDeprecated handles the legacy token processing (it has the same methods as SepaTokens)

