### PR TITLE
Fix for #667 - Made account holder optional for create one off mandate form processor action

### DIFF
--- a/Civi/Sepa/ActionProvider/Action/CreateOneOffMandate.php
+++ b/Civi/Sepa/ActionProvider/Action/CreateOneOffMandate.php
@@ -48,7 +48,7 @@ class CreateOneOffMandate extends AbstractAction {
     return new SpecificationBag([
         // required fields
         new Specification('contact_id',     'Integer', E::ts('Contact ID'), true),
-        new Specification('account_holder', 'String',  E::ts('Account Holder'), true),
+        new Specification('account_holder', 'String',  E::ts('Account Holder'), false),
         new Specification('iban',           'String',  E::ts('IBAN'), true),
         new Specification('bic',            'String',  E::ts('BIC'), true),
         new Specification('reference',      'String',  E::ts('Mandate Reference'), false),


### PR DESCRIPTION
**Before**

In the form processor the action for creating one off mandates has a required field for account holder

**After**

The field is not required anymore

This is a similar fix as #668 