### PR TITLE
Fix for issue #681 made bic optional in the form processor create mandate and create one off mandate actions

### DIFF
--- a/Civi/Sepa/ActionProvider/Action/CreateOneOffMandate.php
+++ b/Civi/Sepa/ActionProvider/Action/CreateOneOffMandate.php
@@ -50,7 +50,7 @@ class CreateOneOffMandate extends AbstractAction {
         new Specification('contact_id',     'Integer', E::ts('Contact ID'), true),
         new Specification('account_holder', 'String',  E::ts('Account Holder'), true),
         new Specification('iban',           'String',  E::ts('IBAN'), true),
-        new Specification('bic',            'String',  E::ts('BIC'), true),
+        new Specification('bic',            'String',  E::ts('BIC'), false),
         new Specification('reference',      'String',  E::ts('Mandate Reference'), false),
         new Specification('amount',         'Money',   E::ts('Amount'), false),
 

--- a/Civi/Sepa/ActionProvider/Action/CreateOneOffMandate.php
+++ b/Civi/Sepa/ActionProvider/Action/CreateOneOffMandate.php
@@ -17,6 +17,7 @@
 namespace Civi\Sepa\ActionProvider\Action;
 
 use \Civi\ActionProvider\Action\AbstractAction;
+use Civi\ActionProvider\Exception\ExecutionException;
 use \Civi\ActionProvider\Parameter\ParameterBagInterface;
 use \Civi\ActionProvider\Parameter\Specification;
 use \Civi\ActionProvider\Parameter\SpecificationBag;
@@ -107,6 +108,12 @@ class CreateOneOffMandate extends AbstractAction {
         $value = $this->configuration->getParameter("default_{$parameter_name}");
       }
       $mandate_data[$parameter_name] = $value;
+    }
+
+    // Check whether BIC is required, depending on the creditor setting.
+    $creditor = civicrm_api3('SepaCreditor', 'getsingle', ['id' => $mandate_data['creditor_id']]);
+    if (!empty($creditor['uses_bic']) && empty($mandate_data['bic'])) {
+      throw new ExecutionException('BIC is required');
     }
 
     // create mandate

--- a/Civi/Sepa/ActionProvider/Action/CreateRecurringMandate.php
+++ b/Civi/Sepa/ActionProvider/Action/CreateRecurringMandate.php
@@ -16,6 +16,7 @@
 
 namespace Civi\Sepa\ActionProvider\Action;
 
+use Civi\ActionProvider\Exception\ExecutionException;
 use \Civi\ActionProvider\Parameter\ParameterBagInterface;
 use \Civi\ActionProvider\Parameter\Specification;
 use \Civi\ActionProvider\Parameter\SpecificationBag;
@@ -113,6 +114,12 @@ class CreateRecurringMandate extends CreateOneOffMandate {
         $value = $this->configuration->getParameter("default_{$parameter_name}");
       }
       $mandate_data[$parameter_name] = $value;
+    }
+
+    // Check whether BIC is required, depending on the creditor setting.
+    $creditor = civicrm_api3('SepaCreditor', 'getsingle', ['id' => $mandate_data['creditor_id']]);
+    if (!empty($creditor['uses_bic']) && empty($mandate_data['bic'])) {
+      throw new ExecutionException('BIC is required');
     }
 
     // sort out frequency

--- a/Civi/Sepa/ActionProvider/Action/CreateRecurringMandate.php
+++ b/Civi/Sepa/ActionProvider/Action/CreateRecurringMandate.php
@@ -51,7 +51,7 @@ class CreateRecurringMandate extends CreateOneOffMandate {
         new Specification('contact_id',     'Integer', E::ts('Contact ID'), true),
         new Specification('account_holder', 'String',  E::ts('Account Holder'), false),
         new Specification('iban',           'String',  E::ts('IBAN'), true),
-        new Specification('bic',            'String',  E::ts('BIC'), true),
+        new Specification('bic',            'String',  E::ts('BIC'), false),
         new Specification('reference',      'String',  E::ts('Mandate Reference'), false),
         new Specification('amount',         'Money',   E::ts('Amount'), false),
 


### PR DESCRIPTION
**Before**

BIC is **required** in the form processor create recurring mandate and create one off mandate actions

**After**

BIC is **optional** in the form processor create recurring mandate and create one off mandate actions