### PR TITLE
Fixed bug in the new token evaluation

### DIFF
--- a/CRM/Utils/SepaTokens.php
+++ b/CRM/Utils/SepaTokens.php
@@ -43,15 +43,15 @@ class CRM_Utils_SepaTokens {
 
   private static function fillLastMandateCommonTokenValues($mandate, $prefix, \Civi\Token\TokenRow $tokenRow) {
     // copy the mandate values
-    $tokenRow->tokens($prefix, 'reference',        $mandate['reference']);
-    $tokenRow->tokens($prefix, 'source',           $mandate['source']);
-    $tokenRow->tokens($prefix, 'type',             $mandate['type']);
-    $tokenRow->tokens($prefix, 'status',           $mandate['status']);
-    $tokenRow->tokens($prefix, 'date',             $mandate['date']);
+    $tokenRow->tokens($prefix, 'reference',        $mandate['reference'] ?? '');
+    $tokenRow->tokens($prefix, 'source',           $mandate['source'] ?? '');
+    $tokenRow->tokens($prefix, 'type',             $mandate['type'] ?? '');
+    $tokenRow->tokens($prefix, 'status',           $mandate['status'] ?? '');
+    $tokenRow->tokens($prefix, 'date',             $mandate['date'] ?? '');
     //$tokenRow->tokens($prefix, 'account_holder',   $mandate['account_holder']);
-    $tokenRow->tokens($prefix, 'iban',             $mandate['iban']);
+    $tokenRow->tokens($prefix, 'iban',             $mandate['iban'] ?? '');
     $tokenRow->tokens($prefix, 'iban_anonymised',  CRM_Sepa_Logic_Verification::anonymiseIBAN($mandate['iban']));
-    $tokenRow->tokens($prefix, 'bic',              $mandate['bic']);
+    $tokenRow->tokens($prefix, 'bic',              $mandate['bic'] ?? '');
 
     if (!empty($mandate['date'])) {
       $tokenRow->tokens($prefix, 'date_text', CRM_Utils_Date::customFormat($mandate['date']));

--- a/sepa.php
+++ b/sepa.php
@@ -502,9 +502,9 @@ function sepa_evaluate_tokens(\Civi\Token\Event\TokenValueEvent $e) {
   $prefix = 'Most_Recent_SEPA_Mandate';
 
   foreach ($e->getRows() as $tokenRow) {
-    if (!empty($row->context['contactId'])) {
-      $row->format('text/html');
-      CRM_Utils_SepaTokens::fillLastMandateTokenValues($row->context['contactId'], $prefix, $tokenRow);
+    if (!empty($tokenRow->context['contactId'])) {
+      $tokenRow->format('text/html');
+      CRM_Utils_SepaTokens::fillLastMandateTokenValues($tokenRow->context['contactId'], $prefix, $tokenRow);
     }
   }
 }


### PR DESCRIPTION
The tokens still did not work in the new token system. (I missed this in the last test because on my system the old token replacement was also active and hid the bug).

Two fixes.
- One misnomed variable.
- Tokes replacement work better with an empty string.