### PR TITLE
Define permissions in the correct format (with `label` and `description`)

### DIFF
--- a/sepa.php
+++ b/sepa.php
@@ -388,17 +388,39 @@ function sepa_civicrm_navigationMenu(&$menu) {
  * Define SEPA permissions
  */
  function sepa_civicrm_permission(&$permissions) {
-  $prefix = ts('CiviSEPA', ['domain' => 'org.project60.sepa']) . ': ';
-  // mandate permissions
-  $permissions['create sepa mandates'] = $prefix . ts('Create SEPA mandates', ['domain' => 'org.project60.sepa']);
-  $permissions['view sepa mandates']   = $prefix . ts('View SEPA mandates', ['domain' => 'org.project60.sepa']);
-  $permissions['edit sepa mandates']   = $prefix . ts('Edit SEPA mandates', ['domain' => 'org.project60.sepa']);
-  $permissions['delete sepa mandates'] = $prefix . ts('Delete SEPA mandates', ['domain' => 'org.project60.sepa']);
+  $prefix = E::ts('CiviSEPA') . ': ';
 
-  // transaction group permissions
-  $permissions['view sepa groups']   = $prefix . ts('View SEPA transaction groups', ['domain' => 'org.project60.sepa']);
-  $permissions['batch sepa groups']  = $prefix . ts('Batch SEPA transaction groups', ['domain' => 'org.project60.sepa']);
-  $permissions['delete sepa groups'] = $prefix . ts('Delete SEPA transaction groups', ['domain' => 'org.project60.sepa']);
+  // Mandate permissions.
+   $permissions['create sepa mandates'] = [
+     'label' => $prefix . E::ts('Create SEPA mandates'),
+     'description' => E::ts('Allows creating SEPA Direct Debit mandates.'),
+   ];
+   $permissions['view sepa mandates'] = [
+     'label' => $prefix . E::ts('View SEPA mandates'),
+     'description' => E::ts('Allows viewing SEPA Direct Debit mandates'),
+   ];
+   $permissions['edit sepa mandates'] = [
+     'label' => $prefix . E::ts('Edit SEPA mandates'),
+     'description' => E::ts('Allows editing SEPA Direct Debit mandates.'),
+   ];
+   $permissions['delete sepa mandates'] = [
+     'label' => $prefix . E::ts('Delete SEPA mandates'),
+     'description' => E::ts('Allows deleting SEPA Direct Debit mandates'),
+   ];
+
+   // Transaction group permissions.
+   $permissions['view sepa groups'] = [
+     'label' => $prefix . E::ts('View SEPA transaction groups'),
+     'description' => E::ts('Allows viewing groups of SEPA transactions to be sent to the bank.'),
+   ];
+   $permissions['batch sepa groups'] = [
+     'label' => $prefix . E::ts('Batch SEPA transaction groups'),
+     'description' => E::ts('Allows generating groups of SEPA transactions to be sent to the bank.'),
+   ];
+   $permissions['delete sepa groups'] = [
+     'label' => $prefix . E::ts('Delete SEPA transaction groups'),
+     'description' => E::ts('Allows deleting groups of SEPA transactions to be sent to the bank.'),
+   ];
  }
 
 


### PR DESCRIPTION
The current method of defining permissions is deprecated in CiviCRM 5.71.