### PR TITLE
Towards supporting Smarty5 (replace addDate by datepicker)

### DIFF
--- a/CRM/Sepa/Form/CreateMandate.php
+++ b/CRM/Sepa/Form/CreateMandate.php
@@ -211,11 +211,12 @@ class CRM_Sepa_Form_CreateMandate extends CRM_Core_Form {
     $this->add('hidden', 'replace', $this->replace_id);
 
     // add the replace date
-    $this->addDate(
+    $this->add('datepicker',
         'rpl_end_date',
         E::ts("Replacement Date"),
+        ['formatType' => 'activityDate'],
         $this->replace_id,
-        array('formatType' => 'activityDate'));
+        ['time' => FALSE]);
 
     // add the replacement/cancel reason
     $this->add(
@@ -227,19 +228,21 @@ class CRM_Sepa_Form_CreateMandate extends CRM_Core_Form {
 
     // add OOFF fields
     // add collection date
-    $this->addDate(
+    $this->add('datepicker',
         'ooff_date',
         E::ts("Collection Date"),
+        ['formatType' => 'activityDate'],
         FALSE,
-        array('formatType' => 'activityDate'));
+        ['time' => FALSE]);
 
     // add RCUR fields
     // add start date
-    $this->addDate(
+    $this->add('datepicker',
         'rcur_start_date',
         E::ts("Start Date"),
+        ['formatType' => 'activityDate'],
         FALSE,
-        array('formatType' => 'activityDate'));
+        ['time' => FALSE]);
 
     // add collection day
     $this->add(
@@ -262,15 +265,15 @@ class CRM_Sepa_Form_CreateMandate extends CRM_Core_Form {
     );
 
     // add end_date
-    $this->addDate(
+    $this->add('datepicker',
         'rcur_end_date',
         E::ts("End Date"),
+        ['formatType' => 'activityDate'],
         FALSE,
-        array('formatType' => 'activityDate'));
+        ['time' => FALSE]);
 
     // finally, add a date field just as a converter
-    $this->addDate('sdd_converter', 'just for date conversion', FALSE, array('formatType' => 'activityDate'));
-
+    $this->add('datepicker', 'sdd_converter', 'just for date conversion', ['formatType' => 'activityDate'], FALSE, ['time' => FALSE]);
 
     // inject JS logic
     CRM_Core_Resources::singleton()->addScriptFile('org.project60.sepa', 'js/CreateMandate.js');

--- a/CRM/Sepa/Form/CreateMandate.php
+++ b/CRM/Sepa/Form/CreateMandate.php
@@ -216,7 +216,8 @@ class CRM_Sepa_Form_CreateMandate extends CRM_Core_Form {
         E::ts("Replacement Date"),
         ['formatType' => 'activityDate'],
         $this->replace_id,
-        ['time' => FALSE]);
+        ['time' => FALSE]
+    );
 
     // add the replacement/cancel reason
     $this->add(
@@ -233,7 +234,8 @@ class CRM_Sepa_Form_CreateMandate extends CRM_Core_Form {
         E::ts("Collection Date"),
         ['formatType' => 'activityDate'],
         FALSE,
-        ['time' => FALSE]);
+        ['time' => FALSE]
+    );
 
     // add RCUR fields
     // add start date
@@ -242,7 +244,8 @@ class CRM_Sepa_Form_CreateMandate extends CRM_Core_Form {
         E::ts("Start Date"),
         ['formatType' => 'activityDate'],
         FALSE,
-        ['time' => FALSE]);
+        ['time' => FALSE]
+    );
 
     // add collection day
     $this->add(
@@ -270,10 +273,18 @@ class CRM_Sepa_Form_CreateMandate extends CRM_Core_Form {
         E::ts("End Date"),
         ['formatType' => 'activityDate'],
         FALSE,
-        ['time' => FALSE]);
+        ['time' => FALSE]
+    );
 
     // finally, add a date field just as a converter
-    $this->add('datepicker', 'sdd_converter', 'just for date conversion', ['formatType' => 'activityDate'], FALSE, ['time' => FALSE]);
+    $this->add(
+      'datepicker',
+      'sdd_converter',
+      'just for date conversion',
+      ['formatType' => 'activityDate'],
+      FALSE,
+      ['time' => FALSE]
+    );
 
     // inject JS logic
     CRM_Core_Resources::singleton()->addScriptFile('org.project60.sepa', 'js/CreateMandate.js');

--- a/js/CreateMandate.js
+++ b/js/CreateMandate.js
@@ -12,7 +12,8 @@
 | written permission from the original author(s).        |
 +--------------------------------------------------------*/
 
-cj(document).ready(function() {
+(function($, _, ts) {
+  $(document).ready(function($) {
     /**
      * Identify and get the jQuery field for the given value
      */
@@ -30,7 +31,9 @@ cj(document).ready(function() {
 
         // flash the field a little bit to indicate change
         sdd_getF(fieldname).parent().fadeOut(50).fadeIn(50);
-        sdd_recalculate_fields();
+        if (recalculate) {
+            sdd_recalculate_fields();
+        }
     }
 
     /**
@@ -38,14 +41,8 @@ cj(document).ready(function() {
      *  using the sdd_converter element
      */
     function sdd_formatDate(date) {
-        cj("#sdd-create-mandate")
-            .find("[name^=sdd_converter].hasDatepicker")
-            .datepicker('setDate', date);
-
-        return cj("#sdd-create-mandate")
-            .find("[name^=sdd_converter_display]").val();
+        return CRM.utils.formatDate(date);
     }
-
 
     // logic to hide OOFF/RCUR fields
     function sdd_change_type() {
@@ -162,9 +159,10 @@ cj(document).ready(function() {
             // no date set yet?
             sdd_setDate('rcur_start_date', rcur_earliest);
         }
+
         cj("#sdd_rcur_earliest")
-            .attr('date', rcur_earliest)
-            .text(ts("earliest: %1", {1: sdd_formatDate(rcur_earliest), domain: 'org.project60.sepa'}));
+            .data('date', rcur_earliest)
+            .text(ts("earliest: %1", {1: CRM.utils.formatDate(rcur_earliest)}));
 
         // CALCULATE SUMMARY TEXT
         let text = ts("<i>Not enough information</i>", {'domain':'org.project60.sepa'});
@@ -286,9 +284,9 @@ cj(document).ready(function() {
     // attach earliest link handlers
     cj("#sdd-create-mandate").find("a.sdd-earliest").click(function() {
         if (cj(this).attr('id') == 'sdd_rcur_earliest') {
-            sdd_setDate('rcur_start_date', new Date(cj(this).attr('date')));
+            sdd_setDate('rcur_start_date', $(this).data('date'));
         } else {
-            sdd_setDate('ooff_date', new Date(cj(this).attr('date')));
+            sdd_setDate('ooff_date', $(this).data('date'));
         }
     });
 
@@ -299,4 +297,5 @@ cj(document).ready(function() {
 
     // trigger the whole thing once
     sdd_creditor_changed();
-});
+  });
+})(CRM.$, CRM._, CRM.ts('org.project60.sepa'));

--- a/js/CreateMandate.js
+++ b/js/CreateMandate.js
@@ -14,6 +14,8 @@
 
 (function($, _, ts) {
   $(document).ready(function($) {
+    let calculationInProgress = false;
+
     /**
      * Identify and get the jQuery field for the given value
      */
@@ -31,9 +33,7 @@
 
         // flash the field a little bit to indicate change
         sdd_getF(fieldname).parent().fadeOut(50).fadeIn(50);
-        if (recalculate) {
-            sdd_recalculate_fields();
-        }
+        sdd_recalculate_fields();
     }
 
     /**
@@ -100,95 +100,109 @@
      * Update the form's start dates and descriptive texts
      */
     function sdd_recalculate_fields() {
-        let today = new Date();
-        let creditor_id = sdd_getF('creditor_id').val();
-        let creditor = CRM.vars.p60sdd.creditor_data[creditor_id];
-        let frequency = parseInt(sdd_getF('interval').val());
-
-        // UPDATE AVAILABLE PAYMENT instruments
-        let available_pis = frequency ? creditor['pi_rcur_options'] : creditor['pi_ooff_options'];
-        let payment_instrument_field = sdd_getF('payment_instrument_id');
-        payment_instrument_field.find('option').remove();
-        for (let available_pi_id in available_pis) {
-            let pi_option = new Option(available_pis[available_pi_id], available_pi_id, false, true);
-            payment_instrument_field.append(pi_option);
+        if (calculationInProgress) {
+            return;
         }
-        payment_instrument_field.change();
+        calculationInProgress = true;
 
-        // hide field if only one option available
-        if (Object.keys(available_pis).length > 1) {
-            payment_instrument_field.parent().parent().show();
-        } else {
-            payment_instrument_field.parent().parent().hide();
-        }
+        try {
+            let today = new Date();
+            let creditor_id = sdd_getF('creditor_id').val();
+            let creditor = CRM.vars.p60sdd.creditor_data[creditor_id];
+            let frequency = parseInt(sdd_getF('interval').val());
 
+            // UPDATE AVAILABLE PAYMENT instruments
+            let available_pis = frequency ? creditor['pi_rcur_options'] : creditor['pi_ooff_options'];
+            let payment_instrument_field = sdd_getF('payment_instrument_id');
+            payment_instrument_field.find('option').remove();
+            for (let available_pi_id in available_pis) {
+              let pi_option = new Option(available_pis[available_pi_id], available_pi_id, false, true);
+              payment_instrument_field.append(pi_option);
+            }
+            payment_instrument_field.change();
 
-        // ADJUST OOFF START DATE
-        let ooff_earliest = new Date(today.getFullYear(), today.getMonth(), today.getDate() + creditor['buffer_days'] + creditor['ooff_notice']);
-        let ooff_current_value = sdd_getF('ooff_date').val();
-        let ooff_new = null;
-        if (ooff_current_value.length > 0) {
-            // parse date and overwrite only if too early
-            let ooff_current = Date.parse(ooff_current_value);
-            if (ooff_earliest > ooff_current) {
+            // hide field if only one option available
+            if (Object.keys(available_pis).length > 1) {
+              payment_instrument_field.parent().parent().show();
+            }
+            else {
+              payment_instrument_field.parent().parent().hide();
+            }
+
+            // ADJUST OOFF START DATE
+            let ooff_earliest = new Date(today.getFullYear(), today.getMonth(), today.getDate() + creditor['buffer_days'] + creditor['ooff_notice']);
+            let ooff_current_value = sdd_getF('ooff_date').val();
+            let ooff_new = null;
+            if (ooff_current_value.length > 0) {
+              // parse date and overwrite only if too early
+              let ooff_current = Date.parse(ooff_current_value);
+              if (ooff_earliest > ooff_current) {
                 sdd_setDate('ooff_date', ooff_earliest);
+              }
             }
-        } else {
-            // no date set yet?
-            sdd_setDate('ooff_date', ooff_earliest);
-        }
-        cj("#sdd_ooff_earliest")
-            .attr('date', ooff_earliest)
-            .text(ts("earliest: %1", {1: sdd_formatDate(ooff_earliest), domain: 'org.project60.sepa'}));
+            else {
+              // no date set yet?
+              sdd_setDate('ooff_date', ooff_earliest);
+            }
+            cj("#sdd_ooff_earliest")
+              .attr('date', ooff_earliest)
+              .text(ts("earliest: %1", { 1: sdd_formatDate(ooff_earliest), domain: 'org.project60.sepa' }));
 
-        // ADJUST RCUR START DATE
-        let rcur_earliest = new Date(today.getFullYear(), today.getMonth(), today.getDate() + creditor['buffer_days'] + creditor['frst_notice']);
-        let cycle_day = parseInt(sdd_getF('cycle_day').val());
-        while (rcur_earliest.getDate() != cycle_day) { // move to next cycle day
-            rcur_earliest = new Date(rcur_earliest.getFullYear(), rcur_earliest.getMonth(), rcur_earliest.getDate() + 1);
-        }
-        let rcur_current_value = sdd_getF('rcur_start_date').val();
-        let rcur_new = null;
-        if (rcur_current_value.length > 0) {
-            // parse date and overwrite only if too early
-            let rcur_current = new Date(rcur_current_value);
-            if (rcur_earliest > rcur_current) {
+            // ADJUST RCUR START DATE
+            let rcur_earliest = new Date(today.getFullYear(), today.getMonth(), today.getDate() + creditor['buffer_days'] + creditor['frst_notice']);
+            let cycle_day = parseInt(sdd_getF('cycle_day').val());
+            while (rcur_earliest.getDate() != cycle_day) { // move to next cycle day
+              rcur_earliest = new Date(rcur_earliest.getFullYear(), rcur_earliest.getMonth(), rcur_earliest.getDate() + 1);
+            }
+            let rcur_current_value = sdd_getF('rcur_start_date').val();
+            let rcur_new = null;
+            if (rcur_current_value.length > 0) {
+              // parse date and overwrite only if too early
+              let rcur_current = new Date(rcur_current_value);
+              if (rcur_earliest > rcur_current) {
                 sdd_setDate('rcur_start_date', rcur_earliest);
+              }
             }
-        } else {
-            // no date set yet?
-            sdd_setDate('rcur_start_date', rcur_earliest);
-        }
+            else {
+              // no date set yet?
+              sdd_setDate('rcur_start_date', rcur_earliest);
+            }
 
-        cj("#sdd_rcur_earliest")
-            .data('date', rcur_earliest)
-            .text(ts("earliest: %1", {1: CRM.utils.formatDate(rcur_earliest)}));
+            cj("#sdd_rcur_earliest")
+              .data('date', rcur_earliest)
+              .text(ts("earliest: %1", { 1: CRM.utils.formatDate(rcur_earliest) }));
 
-        // CALCULATE SUMMARY TEXT
-        let text = ts("<i>Not enough information</i>", {'domain':'org.project60.sepa'});
-        let amount = sdd_getAmount();
-        let money_display = CRM.formatMoney(amount);
-        if (amount) {
-            if (frequency == 0) {
+            // CALCULATE SUMMARY TEXT
+            let text = ts("<i>Not enough information</i>", { 'domain': 'org.project60.sepa' });
+            let amount = sdd_getAmount();
+            let money_display = CRM.formatMoney(amount);
+            if (amount) {
+              if (frequency == 0) {
                 let my_start_date = new Date(sdd_getF('ooff_date').val());
                 text = ts("Collects %1 on %2", {
-                    1: money_display,
-                    2: sdd_formatDate(my_start_date),
-                    'domain':'org.project60.sepa'});
-            } else {
+                  1: money_display,
+                  2: sdd_formatDate(my_start_date),
+                  'domain': 'org.project60.sepa'
+                });
+              }
+              else {
                 let annual_display = CRM.formatMoney(amount * frequency);
                 let my_start_date = new Date(sdd_getF('rcur_start_date').val());
                 text = ts("Collects %1 %2 on the %3., beginning %4.<br/>Annual amount is %5.", {
-                    1: money_display,
-                    2: sdd_getF('interval').find('option[value=' + frequency + ']').text(),
-                    3: sdd_getF('cycle_day').val(),
-                    4: sdd_formatDate(my_start_date),
-                    5: annual_display,
-                    'domain':'org.project60.sepa'});
+                  1: money_display,
+                  2: sdd_getF('interval').find('option[value=' + frequency + ']').text(),
+                  3: sdd_getF('cycle_day').val(),
+                  4: sdd_formatDate(my_start_date),
+                  5: annual_display,
+                  'domain': 'org.project60.sepa'
+                });
+              }
             }
+            // update text
+            cj("#sdd_summary_text").html(text);
+        } finally {
+            calculationInProgress = false;
         }
-        // update text
-        cj("#sdd_summary_text").html(text);
     }
 
     // logic to update creditor-based stuff

--- a/templates/CRM/Sepa/Form/CreateMandate.tpl
+++ b/templates/CRM/Sepa/Form/CreateMandate.tpl
@@ -29,7 +29,7 @@
 
     <div class="crm-section">
       <div class="label">{$form.rpl_end_date.label}</div>
-      <div class="content">{include file="CRM/common/jcalendar.tpl" elementName='rpl_end_date'}</div>
+      <div class="content">{$form.rpl_end_date.html}</div>
       <div class="clear"></div>
     </div>
 
@@ -117,7 +117,7 @@
     <div class="crm-section">
       <div class="label">{$form.ooff_date.label}</div>
       <div class="content">
-          {include file="CRM/common/jcalendar.tpl" elementName='ooff_date'}
+          {$form.ooff_date.html}
           <a id="sdd_ooff_earliest" class="sdd-earliest"></a>
       </div>
       <div class="clear"></div>
@@ -129,7 +129,7 @@
     <div class="crm-section">
       <div class="label">{$form.rcur_start_date.label}</div>
       <div class="content">
-          {include file="CRM/common/jcalendar.tpl" elementName='rcur_start_date'}
+          {$form.rcur_start_date.html}
           <a id="sdd_rcur_earliest" class="sdd-earliest"></a>
       </div>
       <div class="clear"></div>
@@ -143,7 +143,7 @@
 
     <div class="crm-section">
       <div class="label">{$form.rcur_end_date.label}</div>
-      <div class="content">{include file="CRM/common/jcalendar.tpl" elementName='rcur_end_date'}</div>
+      <div class="content">{$form.rcur_end_date.html}</div>
       <div class="clear"></div>
     </div>
   </div>
@@ -162,9 +162,9 @@
     <div class="clear"></div>
   </div>
 
-    <div class="crm-section" style="display: none;">
-        <div class="content">{include file="CRM/common/jcalendar.tpl" elementName='sdd_converter'}</div>
-    </div>
+  <div class="crm-section" style="display: none;">
+    <div class="content">{$form.sdd_converter.html}</div>
+  </div>
 </div>
 
 


### PR DESCRIPTION
Fixes a few jcalendar/smarty5 issues on the "Create new Mandate" form, but it still has a bug, which unfortunately I could not figure out.

To reproduce: enable smarty5 (by default in CiviCRM 5.80+), enable SEPA ext, and then create a new mandate. The popup will fail with a network error, and the error will be `Syntax error in template "file:CRM/common/jcalendar.tpl" `.

This PR includes:

- Replaces `$form->addDate` by `$form->add('datepicker', ...`
- Removes `jcalendar` from the tpl files (it does not work on smarty5)
- Uses `CRM.utils.formatDate()` for formatting dates
- Fixes the JavaScript closure so that we can use `$` and `ts`  without the `domain` (but didn't change everything)

This PR has a bug:

-  `sdd_recalculate_fields` recalculates all fields, and also updates them, which causes recursive updates if we want to trigger "change" so that things like selecting the earliest rcur start date works. I don't know enough about the logic of the code to be sure that I will not be introducing bugs.