### PR TITLE
Use `string_format` instead of `sprintf` in `CloseGroup.tpl`

### DIFF
--- a/templates/CRM/Sepa/Page/CloseGroup.tpl
+++ b/templates/CRM/Sepa/Page/CloseGroup.tpl
@@ -19,7 +19,7 @@
 			{capture assign=group_text}
 			<font size="+1">{ts domain="org.project60.sepa"}Group '%s' <b>is now closed</b> and cannot be changed any more.{/ts}</font>
 			{/capture}
-			<p>{$group_text|sprintf:$txgroup.reference}</p>
+			<p>{$txgroup.reference|string_format:$group_text}</p>
 			{if $allow_xml}
 				<p><font size="+0.5">{ts domain="org.project60.sepa"}The money should be on its way{/ts}</font></p>
 			{else}


### PR DESCRIPTION
This replaces the Smarty modifier `sprintf` with [`string_format`](https://www.smarty.net/docs/en/language.modifier.string.format.tpl).

The usage of `sprintf` resulted in this error:

`Syntax error in template "file:CRM/Sepa/Page/CloseGroup.tpl" on line 22 "<p>{$group_text|sprintf:$txgroup.reference}</p>" unknown modifier 'sprintf'`