### PR TITLE
Improve locking

### DIFF
--- a/CRM/Sepa/Logic/Queue/Close.php
+++ b/CRM/Sepa/Logic/Queue/Close.php
@@ -94,6 +94,8 @@ class CRM_Sepa_Logic_Queue_Close {
         $queue->createItem(new CRM_Sepa_Logic_Queue_Close('create_xml', $txgroup, $target_group_status, $asyncLockId));
       }
       $queue->createItem(new CRM_Sepa_Logic_Queue_Close('set_group_status', $txgroup, $target_group_status, $asyncLockId));
+
+      $queue->createItem(new CRM_Sepa_Logic_Queue_Close('FINISH', $txgroup, $target_group_status, $asyncLockId));
     }
 
     // create a runner and launch it
@@ -137,14 +139,17 @@ class CRM_Sepa_Logic_Queue_Close {
                              [1 => $txgroup['reference']]);
         break;
 
+      case 'FINISH':
+        $this->title = E::ts('Lock released');
+        break;
+
       default:
         $this->title = "Unknown";
     }
   }
 
   public function run($context): bool {
-    $lock = SepaBatchLockManager::getInstance()->getLock();
-    if (!$lock->acquire(10, $this->asyncLockId)) {
+    if (!SepaBatchLockManager::getInstance()->acquire(10, $this->asyncLockId)) {
       throw new \RuntimeException('Unable to acquire lock');
     }
 
@@ -172,6 +177,10 @@ class CRM_Sepa_Logic_Queue_Close {
           'id'        => $this->txgroup['id'],
           'status_id' => $this->targetStatusId,
           ]);
+        break;
+
+      case 'FINISH':
+        SepaBatchLockManager::getInstance()->release($this->asyncLockId);
         break;
 
       default:

--- a/CRM/Sepa/Logic/Queue/Update.php
+++ b/CRM/Sepa/Logic/Queue/Update.php
@@ -122,8 +122,7 @@ class CRM_Sepa_Logic_Queue_Update {
   }
 
   public function run($context): bool {
-    $lock = SepaBatchLockManager::getInstance()->getLock();
-    if (!$lock->acquire(10, $this->asyncLockId)) {
+    if (!SepaBatchLockManager::getInstance()->acquire(10, $this->asyncLockId)) {
       throw new \RuntimeException('Unable to acquire lock');
     }
 
@@ -151,7 +150,7 @@ class CRM_Sepa_Logic_Queue_Update {
         break;
 
       case 'FINISH':
-        $lock->release($this->asyncLockId);
+        SepaBatchLockManager::getInstance()->release($this->asyncLockId);
         break;
 
       default:

--- a/CRM/Sepa/Upgrader.php
+++ b/CRM/Sepa/Upgrader.php
@@ -511,4 +511,10 @@ class CRM_Sepa_Upgrader extends CRM_Extension_Upgrader_Base {
     }
     return TRUE;
   }
+
+  public function upgrade_11302(): bool {
+    CRM_Core_DAO::executeQuery("DELETE FROM civicrm_setting WHERE name='sdd_async_batching_lock'");
+
+    return TRUE;
+  }
 }

--- a/Civi/Sepa/Lock/SepaAsyncBatchLock.php
+++ b/Civi/Sepa/Lock/SepaAsyncBatchLock.php
@@ -118,7 +118,7 @@ final class SepaAsyncBatchLock {
         throw new \RuntimeException("Couldn't remove {$this->lockFilePath}");
       }
     }
-    else if (FALSE === file_put_contents($this->lockFilePath, $id)) {
+    elseif (FALSE === file_put_contents($this->lockFilePath, $id)) {
       throw new \RuntimeException("Couldn't write {$this->lockFilePath}");
     }
   }

--- a/Civi/Sepa/Lock/SepaAsyncBatchLock.php
+++ b/Civi/Sepa/Lock/SepaAsyncBatchLock.php
@@ -31,10 +31,10 @@ final class SepaAsyncBatchLock {
 
   private ?string $acquiredId = NULL;
 
-  private string $lockFile;
+  private string $lockFilePath;
 
-  public function __construct(string $lockFile) {
-    $this->lockFile = $lockFile;
+  public function __construct(string $lockFilePath) {
+    $this->lockFilePath = $lockFilePath;
   }
 
   public function acquire(string $id): bool {
@@ -61,14 +61,14 @@ final class SepaAsyncBatchLock {
    *   is free.
    */
   public function getAcquireTime(): ?int {
-    if (!file_exists($this->lockFile)) {
+    if (!file_exists($this->lockFilePath)) {
       return NULL;
     }
 
-    clearstatcache(TRUE, $this->lockFile);
-    $time = filemtime($this->lockFile);
+    clearstatcache(TRUE, $this->lockFilePath);
+    $time = filemtime($this->lockFilePath);
     if (FALSE === $time) {
-      throw new \RuntimeException("Couldn't get modification time of {$this->lockFile}");
+      throw new \RuntimeException("Couldn't get modification time of {$this->lockFilePath}");
     }
 
     return $time;
@@ -96,13 +96,13 @@ final class SepaAsyncBatchLock {
   }
 
   private function getAsyncLockId(): ?string {
-    if (!file_exists($this->lockFile)) {
+    if (!file_exists($this->lockFilePath)) {
       return NULL;
     }
 
-    $id = file_get_contents($this->lockFile);
+    $id = file_get_contents($this->lockFilePath);
     if (FALSE === $id) {
-      throw new \RuntimeException("Couldn't read {$this->lockFile}");
+      throw new \RuntimeException("Couldn't read {$this->lockFilePath}");
     }
 
     return $id;
@@ -114,12 +114,12 @@ final class SepaAsyncBatchLock {
   private function setAsyncLock(?string $id): void {
     $this->acquiredId = $id;
     if (NULL === $this->acquiredId) {
-      if (!unlink($this->lockFile)) {
-        throw new \RuntimeException("Couldn't remove {$this->lockFile}");
+      if (!unlink($this->lockFilePath)) {
+        throw new \RuntimeException("Couldn't remove {$this->lockFilePath}");
       }
     }
-    else if (FALSE === file_put_contents($this->lockFile, $id)) {
-      throw new \RuntimeException("Couldn't write {$this->lockFile}");
+    else if (FALSE === file_put_contents($this->lockFilePath, $id)) {
+      throw new \RuntimeException("Couldn't write {$this->lockFilePath}");
     }
   }
 

--- a/Civi/Sepa/Lock/SepaAsyncBatchLock.php
+++ b/Civi/Sepa/Lock/SepaAsyncBatchLock.php
@@ -29,29 +29,30 @@ namespace Civi\Sepa\Lock;
  */
 final class SepaAsyncBatchLock {
 
-  private string $name;
+  private ?string $acquiredId = NULL;
 
-  public function __construct(string $name) {
-    $this->name = $name;
+  private string $lockFile;
+
+  public function __construct(string $lockFile) {
+    $this->lockFile = $lockFile;
   }
 
   public function acquire(string $id): bool {
-    $locks = $this->getAsyncLocks();
-    if (($locks[$this->name]['id'] ?? $id) !== $id) {
+    if (($this->getAsyncLockId() ?? $id) !== $id) {
       return FALSE;
     }
 
-    $locks[$this->name] = [
-      'id' => $id,
-      'acquireTime' => time(),
-    ];
-    $this->setAsyncLocks($locks);
+    $this->setAsyncLock($id);
 
     return TRUE;
   }
 
-  public function isAcquired(string $id): bool {
-    return ($this->getAsyncLock()['id'] ?? NULL) === $id;
+  public function isAcquired(?string $id = NULL): bool {
+    if ($id === NULL) {
+      return NULL !== $this->acquiredId && $this->acquiredId === $this->getAsyncLockId();
+    }
+
+    return $this->acquiredId === $id && $this->getAsyncLockId() === $id;
   }
 
   /**
@@ -60,21 +61,29 @@ final class SepaAsyncBatchLock {
    *   is free.
    */
   public function getAcquireTime(): ?int {
-    return $this->getAsyncLock()['acquireTime'] ?? NULL;
+    if (!file_exists($this->lockFile)) {
+      return NULL;
+    }
+
+    clearstatcache(TRUE, $this->lockFile);
+    $time = filemtime($this->lockFile);
+    if (FALSE === $time) {
+      throw new \RuntimeException("Couldn't get modification time of {$this->lockFile}");
+    }
+
+    return $time;
   }
 
   public function isFree(): bool {
-    return $this->getAcquireTime() === NULL;
+    return NULL === $this->acquiredId && $this->getAcquireTime() === NULL;
   }
 
   public function release(string $id): bool {
-    $locks = $this->getAsyncLocks();
-    if (($locks[$this->name]['id'] ?? $id) !== $id) {
+    if (($this->getAsyncLockId() ?? $id) !== $id) {
       return FALSE;
     }
 
-    unset($locks[$this->name]);
-    $this->setAsyncLocks($locks);
+    $this->setAsyncLock(NULL);
 
     return TRUE;
   }
@@ -83,30 +92,35 @@ final class SepaAsyncBatchLock {
    * Releases the lock without specifying the ID.
    */
   public function releaseAny(): void {
-    $locks = $this->getAsyncLocks();
-    unset($locks[$this->name]);
-    $this->setAsyncLocks($locks);
+    $this->setAsyncLock(NULL);
   }
 
-  /**
-   * @phpstan-return array{id: string, acquireTime: int}|null
-   */
-  private function getAsyncLock(): ?array {
-    return $this->getAsyncLocks()[$this->name] ?? NULL;
-  }
+  private function getAsyncLockId(): ?string {
+    if (!file_exists($this->lockFile)) {
+      return NULL;
+    }
 
-  /**
-   * @phpstan-return array<string, array{id: string, acquireTime: int}>
-   */
-  private function getAsyncLocks(): array {
-    return \CRM_Sepa_Logic_Settings::getGenericSetting('sdd_async_batching_lock') ?? [];
+    $id = file_get_contents($this->lockFile);
+    if (FALSE === $id) {
+      throw new \RuntimeException("Couldn't read {$this->lockFile}");
+    }
+
+    return $id;
   }
 
   /**
    * @phpstan-param array<string, array{id: string, acquireTime: int}> $locks
    */
-  private function setAsyncLocks(array $locks): void {
-    \CRM_Sepa_Logic_Settings::setGenericSetting($locks, 'sdd_async_batching_lock');
+  private function setAsyncLock(?string $id): void {
+    $this->acquiredId = $id;
+    if (NULL === $this->acquiredId) {
+      if (!unlink($this->lockFile)) {
+        throw new \RuntimeException("Couldn't remove {$this->lockFile}");
+      }
+    }
+    else if (FALSE === file_put_contents($this->lockFile, $id)) {
+      throw new \RuntimeException("Couldn't write {$this->lockFile}");
+    }
   }
 
 }

--- a/docs/locking.md
+++ b/docs/locking.md
@@ -1,0 +1,50 @@
+# Locking
+
+This chapter describes how the locking mechanism works that prevents parallel
+changes that might lead to inconsistencies. It's rather technical and not
+relevant for most users.
+
+Because of batch processing using
+[queues](https://docs.civicrm.org/dev/en/latest/framework/queues/) we cannot
+purely rely on standard blocking locks. CiviCRM uses the database function
+[`GET_LOCK`](https://mariadb.com/kb/en/get_lock/) for these. The complete queue
+processing has to be protected, but every batch runs in a separate HTTP call. At
+the end of every HTTP request all locks acquired with `GET_LOCK` are
+automatically released. This would make it possible to acquire the database lock
+and perform changes in between the HTTP calls of the batch processing.
+
+To prevent this an additional lock is used. It is a file-based non-blocking lock
+that has the following characteristics:
+
+* Acquiring is done with an ID (random string) that is written into the file.
+* The time of the last acquiring is the modification time of the file.
+* If the file exists, it means that the lock is acquired. (Re-)acquiring is then
+  only possible with the ID that was used previously.
+* On release the file is removed.
+
+How this two types of locks are combined is described in the following. If not
+otherwise stated failing to acquire a lock will prevent a change request.
+
+When running queue items at first a database lock is acquired (with wait time)
+then the file-based lock is (re-)acquired using the same ID for every batch.
+
+When performing an action that make changes (inside or outside of batch
+processing) a database lock is acquired, and it is checked if the file-based
+lock is already acquired (batch processing) or free (no batch processing).
+
+If the file-based lock is not free, there might be a batch processing where
+currently a queue item switch is done. In that case the database lock is
+released and and the process is interrupted for a short time (`sleep()`). This
+gives a possible batch running the chance to acquire the database lock and to
+continue its work. In case a queue is running, it would re-acquire the
+file-based lock and so change the acquire time. Thus, when the interruption is
+finished the acquire time is checked. If it has been changed, there's a queue
+running and the requested change is prevented. Otherwise, there's no queue
+running, but the file-based lock wasn't released for some reason. In that case
+the database lock is acquired, the file-based lock is released and the change is
+executed.
+
+For implementation details see
+[`SepaBatchLockManager`](../Civi/Sepa/Lock/SepaBatchLockManager.php),
+[`SepaBatchLock`](../Civi/Sepa/Lock/SepaBatchLock.php), and
+[`SepaAsyncBatchLock`](../Civi/Sepa/Lock/SepaAsyncBatchLock.php).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: CiviSEPA
 site_description: SEPA Direct Debit Extension
 repo_url: https://github.com/Project60/org.project60.sepa
-theme: 
+theme:
   name: material
 
 nav:
@@ -10,13 +10,14 @@ nav:
 - A basic configuration that will work: config-example.md
 - Terminology: terminology.md
 - How To Guide: how-to.md
+- Locking: locking.md
 
 markdown_extensions:
   - attr_list
   - admonition
   - def_list
   - codehilite
-  - toc: 
+  - toc:
       permalink: true
   - pymdownx.superfences
   - pymdownx.inlinehilite


### PR DESCRIPTION
The first approach in #744 to fix #738 didn't work as expected. In between the HTTP requests for every queue item it was still possible to acquire the CiviCRM lock when a queue was running. The `\Civi\Sepa\Lock\SepaAsyncBatchLock` now uses a file instead of the DB. This allows to check if the acquire time is changed. This wouldn't be possible with the previous usage of the DB during an open transaction.

Releasing the CiviCRM lock and checking if the async lock is acquired is now also working better.

systopia-reference: 28126