### PR TITLE
Fix date comparison in query for finding obsolete contributions when terminating mandates

### DIFF
--- a/CRM/Sepa/BAO/SEPAMandate.php
+++ b/CRM/Sepa/BAO/SEPAMandate.php
@@ -474,10 +474,11 @@ class CRM_Sepa_BAO_SEPAMandate extends CRM_Sepa_DAO_SEPAMandate {
     // find already created contributions that are now obsolete...
     $obsolete_ids = array();
     $deleted_ids = array();
+    $newEndDate = date('Y-m-d', $new_end_date);
     $obsolete_query = "
     SELECT id
     FROM civicrm_contribution
-    WHERE receive_date > '$new_end_date_str'
+    WHERE receive_date > '$newEndDate'
       AND contribution_recur_id = $contribution_id
       AND contribution_status_id = $contribution_id_pending;";
     $obsolete_ids_query = CRM_Core_DAO::executeQuery($obsolete_query);


### PR DESCRIPTION
Terminating mandates currently fails when constructing queries with `WHERE receive_date = 'today'` when trying to identify obsolete contributions. This PR formats the date for MySQL, but the query should probably be replaced with an APIv4 call instead.

Since this never seems to have been found it could probably use a test for all possible values for the date value passed to `\CRM_Sepa_BAO_SEPAMandate::terminateMandate()` in `$new_end_date_str`. The method's signature is not clear about what it expects.

This should be backported to `1.12`.