### PR TITLE
Display custom fields for SepaMandate

### DIFF
--- a/templates/Sepa/Contribute/Form/ContributionView.tpl
+++ b/templates/Sepa/Contribute/Form/ContributionView.tpl
@@ -35,6 +35,7 @@
         <tr><td class="label">{ts domain="org.project60.sepa"}Validation date{/ts}</td><td>{$sepa.validation_date}</td></tr>
       </table>
     </div>
+    {include file="CRM/common/customDataBlock.tpl" groupID='' customDataType='SepaMandate' cid=false entityID=$sepa.id}
   </div>
 </div>
 </td></tr></tbody></table>

--- a/templates/Sepa/Contribute/Page/ContributionRecur.tpl
+++ b/templates/Sepa/Contribute/Page/ContributionRecur.tpl
@@ -32,6 +32,7 @@
             <tr><td class="label">{ts domain="org.project60.sepa"}1st contribution{/ts}</td><td><a href="{crmURL p='civicrm/contact/view/contribution' q="reset=1&action=view&id=$fcid&cid=$cid"}">{$sepa.first_contribution_id}</a></td></tr>
         </table>
     </div>
+    {include file="CRM/common/customDataBlock.tpl" groupID='' customDataType='SepaMandate' cid=false entityID=$sepa.id}
 </div>
 
 {if $can_edit_mandate}


### PR DESCRIPTION
Display custom fields for `SepaMandate` in contribution view.

The styling isn't perfect (the CSS class `crm-info-panel` should be set in the `table` element), though as the template comes from CiviCRM there's no direct way to influence this.

systopia-reference: 28482