### PR TITLE
Do not check Authorization when getting a SepaMandate in SepaMandate pre hook

### DIFF
--- a/CRM/Sepa/BAO/SEPAMandate.php
+++ b/CRM/Sepa/BAO/SEPAMandate.php
@@ -52,12 +52,11 @@ class CRM_Sepa_BAO_SEPAMandate extends CRM_Sepa_DAO_SEPAMandate implements HookI
       }
       else {
         // existing mandate, get creditor
-        $params['creditor_id'] =
-          SepaMandate::get(TRUE)->addSelect('creditor_id')->addWhere(
-            'id',
-            '=',
-            $params['id']
-          )->execute()->single()['creditor_id'];
+        $params['creditor_id'] = SepaMandate::get(FALSE)
+          ->addSelect('creditor_id')
+          ->addWhere('id', '=', $params['id'])
+          ->execute()
+          ->single()['creditor_id'];
       }
     }
     $creditor = SepaCreditor::get(FALSE)


### PR DESCRIPTION
…andate

We have a public contribution page to let people register for payed memberships and use sepapp legacy. After the last update of org.project60.sepa this public contribution page breaks because at the changed place the api call is not authenticated. In my Opinion this is not necessary, because  anonymous users need to fill this contribution page.