### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/templates/CRM/Admin/Form/Setting/SepaSettings.tpl
+++ b/templates/CRM/Admin/Form/Setting/SepaSettings.tpl
@@ -72,37 +72,37 @@ div.sdd-add-creditor {
      <h3>{ts}Creditor Information{/ts}</h3>
      <table id="creditorinfo" class="form-layout">
         <tr>
-         <td class="label">{$form.addcreditor_label.label} <a onclick='CRM.help("{ts}Creditor Label{/ts}", {literal}{"id":"id-label","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+         <td class="label">{$form.addcreditor_label.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Creditor Label{/ts}", {literal}{"id":"id-label","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
          <td>
            {$form.addcreditor_label.html}
          </td>
         </tr>
         <tr>
-         <td class="label">{$form.addcreditor_name.label} <a onclick='CRM.help("{ts}Creditor Name{/ts}", {literal}{"id":"id-name","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+         <td class="label">{$form.addcreditor_name.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Creditor Name{/ts}", {literal}{"id":"id-name","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
          <td>
            {$form.addcreditor_name.html}
          </td>
         </tr>
         <tr>
-          <td class="label">{$form.is_test_creditor.label} <a onclick='CRM.help("{ts}Test Creditor{/ts}", {literal}{"id":"id-test-creditor","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+          <td class="label">{$form.is_test_creditor.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Test Creditor{/ts}", {literal}{"id":"id-test-creditor","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
           <td>
             {$form.is_test_creditor.html}
           </td>
         </tr>
         <tr>
-          <td class="label">{$form.addcreditor_creditor_id.label} <a onclick='CRM.help("{ts}Creditor Contact{/ts}", {literal}{"id":"id-contact","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+          <td class="label">{$form.addcreditor_creditor_id.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Creditor Contact{/ts}", {literal}{"id":"id-contact","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
           <td>
             {$form.addcreditor_creditor_id.html}
           </td>
         </tr>
         <tr>
-          <td class="label">{$form.addcreditor_address.label} <a onclick='CRM.help("{ts}Creditor Address{/ts}", {literal}{"id":"id-address","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+          <td class="label">{$form.addcreditor_address.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Creditor Address{/ts}", {literal}{"id":"id-address","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
           <td>
             {$form.addcreditor_address.html}
           </td>
         </tr>
         <tr>
-          <td class="label">{$form.addcreditor_country_id.label} <a onclick='CRM.help("{ts}Creditor Country{/ts}", {literal}{"id":"id-country","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+          <td class="label">{$form.addcreditor_country_id.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Creditor Country{/ts}", {literal}{"id":"id-country","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
           <td>
             {$form.addcreditor_country_id.html}
           </td>
@@ -114,61 +114,61 @@ div.sdd-add-creditor {
           </td>
         </tr>
         <tr>
-          <td class="label">{$form.addcreditor_id.label} <a onclick='CRM.help("{ts}Creditor Identifier{/ts}", {literal}{"id":"id-id","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+          <td class="label">{$form.addcreditor_id.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Creditor Identifier{/ts}", {literal}{"id":"id-id","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
           <td>
             {$form.addcreditor_id.html}
           </td>
         </tr>
         <tr>
-          <td class="label">{$form.addcreditor_iban.label} <a onclick='CRM.help("{ts}IBAN{/ts}", {literal}{"id":"id-iban","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+          <td class="label">{$form.addcreditor_iban.label} <a onclick='CRM.help("{ts escape='htmlattribute'}IBAN{/ts}", {literal}{"id":"id-iban","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
           <td>
             {$form.addcreditor_iban.html}
           </td>
         </tr>
         <tr>
-          <td class="label">{$form.addcreditor_bic.label} <a onclick='CRM.help("{ts}BIC{/ts}", {literal}{"id":"id-bic","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+          <td class="label">{$form.addcreditor_bic.label} <a onclick='CRM.help("{ts escape='htmlattribute'}BIC{/ts}", {literal}{"id":"id-bic","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
           <td>
             {$form.addcreditor_bic.html}
           </td>
         </tr>
         <tr>
-          <td class="label">{$form.addcreditor_cuc.label} <a onclick='CRM.help("{ts}CUC{/ts}", {literal}{"id":"id-cuc","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+          <td class="label">{$form.addcreditor_cuc.label} <a onclick='CRM.help("{ts escape='htmlattribute'}CUC{/ts}", {literal}{"id":"id-cuc","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
           <td>
             {$form.addcreditor_cuc.html}
           </td>
         </tr>
         <tr>
-          <td class="label">{$form.addcreditor_pain_version.label} <a onclick='CRM.help("{ts}PAIN Version{/ts}", {literal}{"id":"id-pain","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+          <td class="label">{$form.addcreditor_pain_version.label} <a onclick='CRM.help("{ts escape='htmlattribute'}PAIN Version{/ts}", {literal}{"id":"id-pain","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
           <td>
             {$form.addcreditor_pain_version.html}
           </td>
         </tr>
         <tr>
-          <td class="label">{$form.addcreditor_type.label} <a onclick='CRM.help("{ts}Creditor Type{/ts}", {literal}{"id":"id-creditor-type","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+          <td class="label">{$form.addcreditor_type.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Creditor Type{/ts}", {literal}{"id":"id-creditor-type","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
           <td>
             {$form.addcreditor_type.html}
           </td>
         </tr>
          <tr>
-             <td class="label">{$form.addcreditor_pi_ooff.label} <a onclick='CRM.help("{ts}One-Off Payment Instruments{/ts}", {literal}{"id":"id-payment-instruments-ooff","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+             <td class="label">{$form.addcreditor_pi_ooff.label} <a onclick='CRM.help("{ts escape='htmlattribute'}One-Off Payment Instruments{/ts}", {literal}{"id":"id-payment-instruments-ooff","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
              <td>
                  {$form.addcreditor_pi_ooff.html}
              </td>
          </tr>
          <tr>
-             <td class="label">{$form.addcreditor_pi_rcur.label} <a onclick='CRM.help("{ts}Recurring Payment Instruments{/ts}", {literal}{"id":"id-payment-instruments-rcur","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+             <td class="label">{$form.addcreditor_pi_rcur.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Recurring Payment Instruments{/ts}", {literal}{"id":"id-payment-instruments-rcur","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
              <td>
                  {$form.addcreditor_pi_rcur.html}
              </td>
          </tr>
          <tr>
-             <td class="label">{$form.addcreditor_uses_bic.label} <a onclick='CRM.help("{ts}Uses BICs{/ts}", {literal}{"id":"id-uses-bic","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+             <td class="label">{$form.addcreditor_uses_bic.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Uses BICs{/ts}", {literal}{"id":"id-uses-bic","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
              <td>
                  {$form.addcreditor_uses_bic.html}
              </td>
          </tr>
         <tr>
-          <td class="label">{$form.custom_txmsg.label} <a onclick='CRM.help("{ts}Transaction Message{/ts}", {literal}{"id":"id-txmsg","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+          <td class="label">{$form.custom_txmsg.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Transaction Message{/ts}", {literal}{"id":"id-txmsg","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
           <td>
             {$form.custom_txmsg.html}
           </td>
@@ -179,43 +179,43 @@ div.sdd-add-creditor {
      <h3>{ts}Custom Batching Settings (for this creditor){/ts}</h3>
      <table id="custombatching" class="form-layout">
             <tr class="crm-custom-form-block-cycle-days">
-              <td class="label">{$form.custom_cycledays.label} <a onclick='CRM.help("{ts}Cycle Day(s){/ts}", {literal}{"id":"id-cycle-days","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.custom_cycledays.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Cycle Day(s){/ts}", {literal}{"id":"id-cycle-days","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>
                 {$form.custom_cycledays.html}
               </td>
             </tr>
             <tr class="crm-custom-form-block-ooff-horizon-days">
-              <td class="label">{$form.custom_OOFF_horizon.label} <a onclick='CRM.help("{ts}Batching Horizon{/ts}", {literal}{"id":"id-ooff-horizon","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.custom_OOFF_horizon.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Batching Horizon{/ts}", {literal}{"id":"id-ooff-horizon","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>
                 {$form.custom_OOFF_horizon.html}
               </td>
             </tr>
             <tr class="crm-custom-form-block-ooff-notice-days">
-              <td class="label">{$form.custom_OOFF_notice.label} <a onclick='CRM.help("{ts}Batching Notice Days{/ts}", {literal}{"id":"id-notice","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.custom_OOFF_notice.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Batching Notice Days{/ts}", {literal}{"id":"id-notice","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>
                 {$form.custom_OOFF_notice.html}
               </td>
             </tr>
             <tr class="crm-custom-form-block-rcur-horizon-days">
-              <td class="label">{$form.custom_RCUR_horizon.label} <a onclick='CRM.help("{ts}Batching Horizon{/ts}", {literal}{"id":"id-rcur-horizon","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.custom_RCUR_horizon.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Batching Horizon{/ts}", {literal}{"id":"id-rcur-horizon","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>
                 {$form.custom_RCUR_horizon.html}
               </td>
             </tr>
             <tr class="crm-custom-form-block-rcur-grace-days">
-              <td class="label">{$form.custom_RCUR_grace.label} <a onclick='CRM.help("{ts}Grace Period{/ts}", {literal}{"id":"id-rcur-grace","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.custom_RCUR_grace.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Grace Period{/ts}", {literal}{"id":"id-rcur-grace","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>
                 {$form.custom_RCUR_grace.html}
               </td>
             </tr>
             <tr class="crm-custom-form-block-rcur-notice-days">
-              <td class="label">{$form.custom_RCUR_notice.label} <a onclick='CRM.help("{ts}Batching Notice Days{/ts}", {literal}{"id":"id-notice","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.custom_RCUR_notice.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Batching Notice Days{/ts}", {literal}{"id":"id-notice","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>
                 {$form.custom_RCUR_notice.html}
               </td>
             </tr>
             <tr class="crm-custom-form-block-frst-notice-days">
-              <td class="label">{$form.custom_FRST_notice.label} <a onclick='CRM.help("{ts}Batching Notice Days{/ts}", {literal}{"id":"id-notice","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.custom_FRST_notice.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Batching Notice Days{/ts}", {literal}{"id":"id-notice","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>
                 {$form.custom_FRST_notice.html}
               </td>
@@ -239,43 +239,43 @@ div.sdd-add-creditor {
         <h2>{ts}Default Batching Settings{/ts}</h2>
         <table class="form-layout">
             <tr class="crm-alternative_batching-form-block-cycle-days">
-              <td class="label">{$form.cycledays.label} <a onclick='CRM.help("{ts}Cycle Day(s){/ts}", {literal}{"id":"id-cycle-days","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.cycledays.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Cycle Day(s){/ts}", {literal}{"id":"id-cycle-days","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>
                 {$form.cycledays.html}
               </td>
             </tr>
             <tr class="crm-alternative_batching-form-block-ooff-horizon-days">
-              <td class="label">{$form.batching_OOFF_horizon.label} <a onclick='CRM.help("{ts}Batching Horizon{/ts}", {literal}{"id":"id-ooff-horizon","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.batching_OOFF_horizon.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Batching Horizon{/ts}", {literal}{"id":"id-ooff-horizon","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>
                 {$form.batching_OOFF_horizon.html}
               </td>
             </tr>
             <tr class="crm-alternative_batching-form-block-ooff-notice-days">
-              <td class="label">{$form.batching_OOFF_notice.label} <a onclick='CRM.help("{ts}Batching Notice Days{/ts}", {literal}{"id":"id-notice","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.batching_OOFF_notice.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Batching Notice Days{/ts}", {literal}{"id":"id-notice","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>
                 {$form.batching_OOFF_notice.html}
               </td>
             </tr>
             <tr class="crm-alternative_batching-form-block-rcur-horizon-days">
-              <td class="label">{$form.batching_RCUR_horizon.label} <a onclick='CRM.help("{ts}Batching Horizon{/ts}", {literal}{"id":"id-rcur-horizon","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.batching_RCUR_horizon.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Batching Horizon{/ts}", {literal}{"id":"id-rcur-horizon","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>
                 {$form.batching_RCUR_horizon.html}
               </td>
             </tr>
             <tr class="crm-alternative_batching-form-block-rcur-grace-days">
-              <td class="label">{$form.batching_RCUR_grace.label} <a onclick='CRM.help("{ts}Grace Period{/ts}", {literal}{"id":"id-rcur-grace","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.batching_RCUR_grace.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Grace Period{/ts}", {literal}{"id":"id-rcur-grace","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>
                 {$form.batching_RCUR_grace.html}
               </td>
             </tr>
             <tr class="crm-alternative_batching-form-block-rcur-notice-days">
-              <td class="label">{$form.batching_RCUR_notice.label} <a onclick='CRM.help("{ts}Batching Notice Days{/ts}", {literal}{"id":"id-notice","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.batching_RCUR_notice.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Batching Notice Days{/ts}", {literal}{"id":"id-notice","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>
                 {$form.batching_RCUR_notice.html}
               </td>
             </tr>
             <tr class="crm-alternative_batching-form-block-frst-notice-days">
-              <td class="label">{$form.batching_FRST_notice.label} <a onclick='CRM.help("{ts}Batching Notice Days{/ts}", {literal}{"id":"id-notice","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.batching_FRST_notice.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Batching Notice Days{/ts}", {literal}{"id":"id-notice","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>
                 {$form.batching_FRST_notice.html}
               </td>
@@ -285,61 +285,61 @@ div.sdd-add-creditor {
        <h2>{ts}System Settings{/ts}</h2>
         <table class="form-layout">
             <tr class="crm-alternative_batching-form-block-batching_default_creditor">
-              <td class="label">{$form.batching_default_creditor.label} <a onclick='CRM.help("{ts}Default Creditor{/ts}", {literal}{"id":"id-defaultcreditor","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.batching_default_creditor.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Default Creditor{/ts}", {literal}{"id":"id-defaultcreditor","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>
                 {$form.batching_default_creditor.html}
               </td>
             </tr>
             <tr class="crm-alternative_batching-form-block-buffer-days">
-                <td class="label">{$form.pp_buffer_days.label} <a onclick='CRM.help("{ts}Recurring Buffer Days{/ts}", {literal}{"id":"id-buffer-days","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+                <td class="label">{$form.pp_buffer_days.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Recurring Buffer Days{/ts}", {literal}{"id":"id-buffer-days","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
                 <td>
                     {$form.pp_buffer_days.html}
                 </td>
             </tr>
             <tr class="crm-alternative_batching-form-block-allow_mandate_modification">
-              <td class="label">{$form.allow_mandate_modification.label} <a onclick='CRM.help("{ts}Mandate Modifications{/ts}", {literal}{"id":"id-mandatemodifications","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.allow_mandate_modification.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Mandate Modifications{/ts}", {literal}{"id":"id-mandatemodifications","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>
                 {$form.allow_mandate_modification.html}
               </td>
             </tr>
             <tr class="crm-alternative_batching-form-block-custom-txmsg">
-              <td class="label">{$form.custom_txmsg.label} <a onclick='CRM.help("{ts}Transaction Message{/ts}", {literal}{"id":"id-txmsg","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.custom_txmsg.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Transaction Message{/ts}", {literal}{"id":"id-txmsg","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>
                 {$form.custom_txmsg.html}
               </td>
             </tr>
             <tr class="crm-alternative_batching-form-block-update-lock_timeout">
-              <td class="label">{$form.batching_UPDATE_lock_timeout.label} <a onclick='CRM.help("{ts}Update lock timeout{/ts}", {literal}{"id":"id-lock","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.batching_UPDATE_lock_timeout.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Update lock timeout{/ts}", {literal}{"id":"id-lock","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>
                 {$form.batching_UPDATE_lock_timeout.html}
               </td>
             </tr>
             <tr class="crm-alternative_batching-form-block-exclude-weekends">
-              <td class="label">{$form.exclude_weekends.label} <a onclick='CRM.help("{ts}Exclude Weekends{/ts}", {literal}{"id":"id-exclude-weekends","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.exclude_weekends.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Exclude Weekends{/ts}", {literal}{"id":"id-exclude-weekends","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>
                 {$form.exclude_weekends.html}
               </td>
             </tr>
             <tr class="crm-alternative_batching-form-block-skip-closed">
-              <td class="label">{$form.sdd_skip_closed.label} <a onclick='CRM.help("{ts}Only Completed Contributions{/ts}", {literal}{"id":"id-skip-closed","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.sdd_skip_closed.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Only Completed Contributions{/ts}", {literal}{"id":"id-skip-closed","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>
                 {$form.sdd_skip_closed.html}
               </td>
             </tr>
             <tr class="crm-alternative_batching-form-block-no-draft-xml">
-              <td class="label">{$form.sdd_no_draft_xml.label} <a onclick='CRM.help("{ts}No XML Draft Files{/ts}", {literal}{"id":"id-no-draft-xml","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.sdd_no_draft_xml.label} <a onclick='CRM.help("{ts escape='htmlattribute'}No XML Draft Files{/ts}", {literal}{"id":"id-no-draft-xml","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>
                 {$form.sdd_no_draft_xml.html}
               </td>
             </tr>
             <tr class="crm-alternative_batching-form-block-async-batching">
-              <td class="label">{$form.sdd_async_batching.label} <a onclick='CRM.help("{ts}Support Large Groups{/ts}", {literal}{"id":"id-async-batching","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.sdd_async_batching.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Support Large Groups{/ts}", {literal}{"id":"id-async-batching","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>
                 {$form.sdd_async_batching.html}
               </td>
             </tr>
             <tr class="crm-alternative_batching-form-block-financial-type-grouping">
-              <td class="label">{$form.sdd_financial_type_grouping.label} <a onclick='CRM.help("{ts}Groups by Financial Types{/ts}", {literal}{"id":"id-financial-type-grouping","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.sdd_financial_type_grouping.label} <a onclick='CRM.help("{ts escape='htmlattribute'}Groups by Financial Types{/ts}", {literal}{"id":"id-financial-type-grouping","file":"CRM\/Admin\/Form\/Setting\/SepaSettings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute'}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>
                 {$form.sdd_financial_type_grouping.html}
               </td>

--- a/templates/CRM/Sepa/Page/CreateMandate.tpl
+++ b/templates/CRM/Sepa/Page/CreateMandate.tpl
@@ -68,15 +68,15 @@
 		</tr>
 		<tr>	<!-- MANDATE REFERENCE -->
 			<td>{ts domain="org.project60.sepa"}Mandate Reference{/ts}:</td>
-			<td><input name="reference" type="text" size="34" value="{$reference}" placeholder="{ts domain="org.project60.sepa"}not required, will be generated{/ts}"/></td>
+			<td><input name="reference" type="text" size="34" value="{$reference}" placeholder="{ts escape='htmlattribute' domain="org.project60.sepa"}not required, will be generated{/ts}"/></td>
 		</tr>
 		<tr>	<!-- SOURCE -->
 			<td>{ts domain="org.project60.sepa"}Source{/ts}:</td>
-			<td><input name="source" type="text" value="{$source}" placeholder="{ts domain="org.project60.sepa"}not required{/ts}"/></td>
+			<td><input name="source" type="text" value="{$source}" placeholder="{ts escape='htmlattribute' domain="org.project60.sepa"}not required{/ts}"/></td>
 		</tr>
 		<tr>	<!-- NOTE -->
 			<td id="mandate_note_label">{ts domain="org.project60.sepa"}Note{/ts}:</td>
-			<td><input name="note" type="text" size="32" value="{$note}" placeholder="{ts domain="org.project60.sepa"}not required{/ts}"/></td>
+			<td><input name="note" type="text" size="32" value="{$note}" placeholder="{ts escape='htmlattribute' domain="org.project60.sepa"}not required{/ts}"/></td>
 		</tr>
 
 		<tr><td colspan="4"><hr></td></tr>
@@ -183,7 +183,7 @@
 			<td></td>
 		</tr>
 	</table>
-	<input type="submit" value="{ts domain="org.project60.sepa"}create{/ts}" />
+	<input type="submit" value="{ts escape='htmlattribute' domain="org.project60.sepa"}create{/ts}" />
 </form>
 
 {else}
@@ -202,10 +202,10 @@
 		{ts domain="org.project60.sepa"}Reference is{/ts}: <font face="Courier New, monospace">{$reference}</font></h2>
 	{/if}
 	<br/><br/>
-	<a href="{$back_url}" class="view button" title="{ts domain="org.project60.sepa"}back to contact{/ts}">
+	<a href="{$back_url}" class="view button" title="{ts escape='htmlattribute' domain="org.project60.sepa"}back to contact{/ts}">
 		<span><div class="icon preview-icon"></div>{ts domain="org.project60.sepa"}view contact{/ts}</span>
 	</a>
-	<a href="{$mandate_url}" class="view button" title="{ts domain="org.project60.sepa"}view mandate{/ts}">
+	<a href="{$mandate_url}" class="view button" title="{ts escape='htmlattribute' domain="org.project60.sepa"}view mandate{/ts}">
 		<span><div class="icon preview-icon"></div>{ts domain="org.project60.sepa"}view mandate{/ts}</span>
 	</a>
 {/if}

--- a/templates/CRM/Sepa/Page/DashBoard.tpl
+++ b/templates/CRM/Sepa/Page/DashBoard.tpl
@@ -17,7 +17,7 @@
   <ul id="actions">
   {if $status eq 'closed'}
     <li>
-      <a title="{ts domain="org.project60.sepa"}show active groups{/ts}" class="search button" href="{$show_open_url}">
+      <a title="{ts escape='htmlattribute' domain="org.project60.sepa"}show active groups{/ts}" class="search button" href="{$show_open_url}">
         <span>
           <div class="icon inform-icon"></div>
           {ts domain="org.project60.sepa"}show active groups{/ts}
@@ -26,7 +26,7 @@
     </li>
   {else}
     <li>
-      <a title="{ts domain="org.project60.sepa"}show closed groups{/ts}" class="search button" href="{$show_closed_url}">
+      <a title="{ts escape='htmlattribute' domain="org.project60.sepa"}show closed groups{/ts}" class="search button" href="{$show_closed_url}">
         <span>
           <div class="icon inform-icon"></div>
           {ts domain="org.project60.sepa"}show closed groups{/ts}
@@ -35,7 +35,7 @@
     <li>
     {if $can_batch}
     <li>
-      <a title="{ts domain="org.project60.sepa"}update one-off{/ts}" class="refresh button" href="{$batch_ooff}">
+      <a title="{ts escape='htmlattribute' domain="org.project60.sepa"}update one-off{/ts}" class="refresh button" href="{$batch_ooff}">
         <span>
           <div class="icon refresh-icon ui-icon-refresh"></div>
           {ts domain="org.project60.sepa"}update one-off{/ts}
@@ -43,7 +43,7 @@
       </a>
     </li>
     <li>
-      <a title="{ts domain="org.project60.sepa"}update recurring{/ts}" class="refresh button" href="{$batch_recur}">
+      <a title="{ts escape='htmlattribute' domain="org.project60.sepa"}update recurring{/ts}" class="refresh button" href="{$batch_recur}">
         <span>
           <div class="icon refresh-icon ui-icon-refresh"></div>
           {ts domain="org.project60.sepa"}update recurring{/ts}
@@ -51,7 +51,7 @@
       </a>
     </li>
       <li>
-        <a title="{ts domain="org.project60.sepa"}retry collection{/ts}" class="refresh button" href="{$batch_retry}">
+        <a title="{ts escape='htmlattribute' domain="org.project60.sepa"}retry collection{/ts}" class="refresh button" href="{$batch_retry}">
         <span>
           <div class="icon refresh-icon  ui-icon-circle-plus"></div>
           {ts domain="org.project60.sepa"}retry collection{/ts}
@@ -87,8 +87,8 @@
   <tr bgcolor="#FF0000" class="status_{$group.status_id} submit_{$group.submit}" data-id="{$group.id}" data-type="{$group.type}">
     <td title="id {$group.id}" class="nb_contrib">
       {$group.reference}
-      {if $group.transaction_message}<span class="crm-i fa-envelope-o" title="{ts domain="org.project60.sepa"}Custom Transaction Message:{/ts} {$group.transaction_message}"></span>{/if}
-      {if $group.transaction_note}<span class="crm-i fa-sticky-note" title="{ts domain="org.project60.sepa"}Note:{/ts} {$group.transaction_note}"></span>{/if}
+      {if $group.transaction_message}<span class="crm-i fa-envelope-o" title="{ts escape='htmlattribute' domain="org.project60.sepa"}Custom Transaction Message:{/ts} {$group.transaction_message}"></span>{/if}
+      {if $group.transaction_note}<span class="crm-i fa-sticky-note" title="{ts escape='htmlattribute' domain="org.project60.sepa"}Note:{/ts} {$group.transaction_note}"></span>{/if}
     </td>
     <td>
       {$group.status_label}

--- a/templates/CRM/Sepa/Page/DeleteGroup.tpl
+++ b/templates/CRM/Sepa/Page/DeleteGroup.tpl
@@ -222,8 +222,8 @@
 	{ts domain="org.project60.sepa"}Are you sure this is what you want to do?{/ts}
 </p>
 <div class="crm-submit-buttons">
-	<input id="ok_button" class="button button_close" type="button" value="{ts domain="org.project60.sepa"}Yes{/ts}" />
-	<input id="cancel_button" class="button button_close" type="button" value="{ts domain="org.project60.sepa"}No{/ts}" />
+	<input id="ok_button" class="button button_close" type="button" value="{ts escape='htmlattribute' domain="org.project60.sepa"}Yes{/ts}" />
+	<input id="cancel_button" class="button button_close" type="button" value="{ts escape='htmlattribute' domain="org.project60.sepa"}No{/ts}" />
 </div>
 </form>
 

--- a/templates/CRM/Sepa/Page/EditMandate.tpl
+++ b/templates/CRM/Sepa/Page/EditMandate.tpl
@@ -111,7 +111,7 @@
             {if $can_modify}{if $contribution.cycle_day}{if $sepa.status eq 'FRST' or $sepa.status eq 'RCUR' or $sepa.status eq 'INIT'}<tr>
               <td class="label" style="vertical-align: middle;"><a class="button" onclick="mandate_action_change_cycle_day();">{ts domain="org.project60.sepa"}Change Cycle Day{/ts}</td>
               <td>
-                  {ts domain="org.project60.sepa"}New cycle day:{/ts}<a id='template_help' onclick='CRM.help("{ts domain="org.project60.sepa"}Cyle Day{/ts}", {literal}{"id":"id-change-cycleday-help","file":"CRM\/Sepa\/Page\/EditMandate"}{/literal}); return false;' href="#" title="{ts domain="org.project60.sepa"}Help{/ts}" class="helpicon">&nbsp;</a>&nbsp;
+                  {ts domain="org.project60.sepa"}New cycle day:{/ts}<a id='template_help' onclick='CRM.help("{ts escape='htmlattribute' domain="org.project60.sepa"}Cyle Day{/ts}", {literal}{"id":"id-change-cycleday-help","file":"CRM\/Sepa\/Page\/EditMandate"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="org.project60.sepa"}Help{/ts}" class="helpicon">&nbsp;</a>&nbsp;
                   <select name="new_cycle_day" id="new_cycle_day" class="crm-form-select">
                     {foreach from=$cycle_days item=cycle_day_label key=cycle_day_value}
                       <option value="{$cycle_day_value}" {if ($cycle_day_value == $contribution.cycle_day_raw)}selected="selected"{/if}>{$cycle_day_label}</option>
@@ -138,7 +138,7 @@
                     {ts domain="org.project60.sepa"}Will generate a Prenotification PDF with this mandate's data.{/ts}
                     <br/>
                     {if !empty($sepa_templates)}
-                    {ts domain="org.project60.sepa"}Select the template to be used:{/ts}<a id='template_help' onclick='CRM.help("{ts domain="org.project60.sepa"}Template{/ts}", {literal}{"id":"id-template-help","file":"CRM\/Sepa\/Page\/EditMandate"}{/literal}); return false;' href="#" title="{ts domain="org.project60.sepa"}Help{/ts}" class="helpicon">&nbsp;</a>
+                    {ts domain="org.project60.sepa"}Select the template to be used:{/ts}<a id='template_help' onclick='CRM.help("{ts escape='htmlattribute' domain="org.project60.sepa"}Template{/ts}", {literal}{"id":"id-template-help","file":"CRM\/Sepa\/Page\/EditMandate"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="org.project60.sepa"}Help{/ts}" class="helpicon">&nbsp;</a>
                     &nbsp;
                     <select id="sepa_tpl_select" style="">
                         {foreach from=$sepa_templates item=item}

--- a/templates/CRM/Sepa/Page/MandateTab.tpl
+++ b/templates/CRM/Sepa/Page/MandateTab.tpl
@@ -69,10 +69,10 @@
       <td>
         <span>
           {if $permissions.view}
-            <a href="{$rcur.view_link}" class="action-item crm-hover-button crm-popup" title="{ts domain="org.project60.sepa"}View Mandate{/ts}">{ts domain="org.project60.sepa"}View{/ts}</a>
+            <a href="{$rcur.view_link}" class="action-item crm-hover-button crm-popup" title="{ts escape='htmlattribute' domain="org.project60.sepa"}View Mandate{/ts}">{ts domain="org.project60.sepa"}View{/ts}</a>
           {/if}
           {if $permissions.edit && $rcur.edit_link}
-            <a href="{$rcur.edit_link}" class="action-item crm-hover-button crm-popup" title="{ts domain="org.project60.sepa"}Edit Mandate{/ts}">{ts domain="org.project60.sepa"}Edit{/ts}</a>
+            <a href="{$rcur.edit_link}" class="action-item crm-hover-button crm-popup" title="{ts escape='htmlattribute' domain="org.project60.sepa"}Edit Mandate{/ts}">{ts domain="org.project60.sepa"}Edit{/ts}</a>
           {/if}
         </span>
       </td>
@@ -114,10 +114,10 @@
       <td>
         <span>
           {if $permissions.view}
-            <a href="{$ooff.view_link}" class="action-item crm-hover-button crm-popup" title="{ts domain="org.project60.sepa"}View Mandate{/ts}">{ts domain="org.project60.sepa"}View{/ts}</a>
+            <a href="{$ooff.view_link}" class="action-item crm-hover-button crm-popup" title="{ts escape='htmlattribute' domain="org.project60.sepa"}View Mandate{/ts}">{ts domain="org.project60.sepa"}View{/ts}</a>
           {/if}
           {if $permissions.edit && $ooff.edit_link}
-            <a href="{$ooff.edit_link}" class="action-item crm-hover-button crm-popup" title="{ts domain="org.project60.sepa"}Edit Mandate{/ts}">{ts domain="org.project60.sepa"}Edit{/ts}</a>
+            <a href="{$ooff.edit_link}" class="action-item crm-hover-button crm-popup" title="{ts escape='htmlattribute' domain="org.project60.sepa"}Edit Mandate{/ts}">{ts domain="org.project60.sepa"}Edit{/ts}</a>
           {/if}
         </span>
       </td>


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.