### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Sepa/BAO/SEPAContributionGroup.php
+++ b/CRM/Sepa/BAO/SEPAContributionGroup.php
@@ -38,7 +38,7 @@ class CRM_Sepa_BAO_SEPAContributionGroup extends CRM_Sepa_DAO_SEPAContributionGr
    */
   static function add(&$params) {
     $hook = empty($params['id']) ? 'create' : 'edit';
-    CRM_Utils_Hook::pre($hook, 'SepaContributionGroup', CRM_Utils_Array::value('id', $params), $params);
+    CRM_Utils_Hook::pre($hook, 'SepaContributionGroup', $params['id'] ?? NULL, $params);
 
     $dao = new CRM_Sepa_DAO_SEPAContributionGroup();
     $dao->copyValues($params);

--- a/CRM/Sepa/BAO/SEPACreditor.php
+++ b/CRM/Sepa/BAO/SEPACreditor.php
@@ -36,7 +36,7 @@ class CRM_Sepa_BAO_SEPACreditor extends CRM_Sepa_DAO_SEPACreditor {
    */
   static function add(&$params) {
     $hook = empty($params['id']) ? 'create' : 'edit';
-    CRM_Utils_Hook::pre($hook, 'SepaCreditor', CRM_Utils_Array::value('id', $params), $params);
+    CRM_Utils_Hook::pre($hook, 'SepaCreditor', $params['id'] ?? NULL, $params);
 
     // add default payment instruments for a new creditor if none provided
     if (empty($params['id']) && !isset($params['pi_ooff']) && !isset($params['pi_rcur'])) {

--- a/CRM/Sepa/BAO/SEPASddFile.php
+++ b/CRM/Sepa/BAO/SEPASddFile.php
@@ -37,7 +37,7 @@ class CRM_Sepa_BAO_SEPASddFile extends CRM_Sepa_DAO_SEPASddFile {
    */
   static function add(&$params) {
     $hook = empty($params['id']) ? 'create' : 'edit';
-    CRM_Utils_Hook::pre($hook, 'SepaSddFile', CRM_Utils_Array::value('id', $params), $params);
+    CRM_Utils_Hook::pre($hook, 'SepaSddFile', $params['id'] ?? NULL, $params);
 
     $dao = new CRM_Sepa_DAO_SEPASddFile();
     $dao->copyValues($params);

--- a/CRM/Sepa/BAO/SEPATransactionGroup.php
+++ b/CRM/Sepa/BAO/SEPATransactionGroup.php
@@ -37,7 +37,7 @@ class CRM_Sepa_BAO_SEPATransactionGroup extends CRM_Sepa_DAO_SEPATransactionGrou
    */
   static function add(&$params) {
     $hook = empty($params['id']) ? 'create' : 'edit';
-    CRM_Utils_Hook::pre($hook, 'SepaTransactionGroup', CRM_Utils_Array::value('id', $params), $params);
+    CRM_Utils_Hook::pre($hook, 'SepaTransactionGroup', $params['id'] ?? NULL, $params);
 
     $dao = new CRM_Sepa_DAO_SEPATransactionGroup();
     $dao->copyValues($params);

--- a/CRM/Sepa/BAO/SepaMandateLink.php
+++ b/CRM/Sepa/BAO/SepaMandateLink.php
@@ -207,7 +207,7 @@ class CRM_Sepa_BAO_SepaMandateLink extends CRM_Sepa_DAO_SepaMandateLink {
       $params['creation_date'] = date('YmdHis');
     }
 
-    CRM_Utils_Hook::pre($hook, 'SepaMandateLink', CRM_Utils_Array::value('id', $params), $params);
+    CRM_Utils_Hook::pre($hook, 'SepaMandateLink', $params['id'] ?? NULL, $params);
 
     $dao = new CRM_Sepa_BAO_SepaMandateLink();
     $dao->copyValues($params);

--- a/CRM/Sepa/CustomData.php
+++ b/CRM/Sepa/CustomData.php
@@ -229,7 +229,7 @@ class CRM_Sepa_CustomData {
         'options'    => array('limit' => 2));
 
     foreach ($data['_lookup'] as $lookup_key) {
-      $lookup_query[$lookup_key] = CRM_Utils_Array::value($lookup_key, $data, '');
+      $lookup_query[$lookup_key] = $data[$lookup_key] ?? '';
     }
 
     $this->log(self::CUSTOM_DATA_HELPER_LOG_DEBUG, "LOOKUP {$entity_type}: " . json_encode($lookup_query));
@@ -721,7 +721,7 @@ class CRM_Sepa_CustomData {
         return $field_data['value'];
       } else {
         // unlikely, but worth a shot:
-        return CRM_Utils_Array::value("custom_{$field_id}", $params, NULL);
+        return $params["custom_{$field_id}"] ?? NULL;
       }
     }
     return NULL;
@@ -769,12 +769,12 @@ class CRM_Sepa_CustomData {
       $group_specs = self::getGroupSpecs($field_specs['custom_group_id']);
       return               [
           'value'           => $value,
-          'type'            => CRM_Utils_Array::value('data_type', $field_specs, 'String'),
+          'type'            => $field_specs['data_type'] ?? 'String',
           'custom_field_id' => $field_id,
-          'custom_group_id' => CRM_Utils_Array::value('custom_group_id', $field_specs, NULL),
-          'table_name'      => CRM_Utils_Array::value('table_name', $group_specs, NULL),
-          'column_name'     => CRM_Utils_Array::value('column_name', $field_specs, NULL),
-          'is_multiple'     => CRM_Utils_Array::value('is_multiple', $group_specs, 0),
+          'custom_group_id' => $field_specs['custom_group_id'] ?? NULL,
+          'table_name'      => $group_specs['table_name'] ?? NULL,
+          'column_name'     => $field_specs['column_name'] ?? NULL,
+          'is_multiple'     => $group_specs['is_multiple'] ?? 0,
       ];
     } else {
       return NULL;

--- a/CRM/Sepa/Form/Report/SepaMandateGeneric.php
+++ b/CRM/Sepa/Form/Report/SepaMandateGeneric.php
@@ -259,21 +259,21 @@ class CRM_Sepa_Form_Report_SepaMandateGeneric extends CRM_Report_Form {
     // add amount from either OOFF or RCUR
     if ($fieldName == 'amount') {
       $this->_columnHeaders['amount']['title'] = $field['title'];
-      $this->_columnHeaders['amount']['type']  = CRM_Utils_Array::value('type', $field);
+      $this->_columnHeaders['amount']['type']  = $field['type'] ?? NULL;
       return "IF(civicrm_contribution.id IS NOT NULL, civicrm_contribution.total_amount, civicrm_contribution_recur.amount) AS amount";
     }
 
     // add status from either OOFF or RCUR
     if ($fieldName == 'status_id') {
       $this->_columnHeaders['status_id']['title'] = $field['title'];
-      $this->_columnHeaders['status_id']['type']  = CRM_Utils_Array::value('type', $field);
+      $this->_columnHeaders['status_id']['type']  = $field['type'] ?? NULL;
       return "IF(civicrm_contribution.id IS NOT NULL, civicrm_contribution.contribution_status_id, civicrm_contribution_recur.contribution_status_id) AS status_id";
     }
 
     // Fallback: generic selector
-    if (CRM_Utils_Array::value('required', $field) || CRM_Utils_Array::value($fieldName, $this->_params['fields'])) {
+    if (!empty($field['required']) || !empty($this->_params['fields'][$fieldName])) {
       $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'];
-      $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+      $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
       return "{$field['dbAlias']} as {$tableName}_{$fieldName}";
     }
 
@@ -305,10 +305,10 @@ class CRM_Sepa_Form_Report_SepaMandateGeneric extends CRM_Report_Form {
     if ($fieldName == 'status_id') {
       if (!empty($this->_params["{$fieldName}_value"])) {
         $base_clause = $this->whereClause($field,
-            CRM_Utils_Array::value("{$fieldName}_op", $this->_params),
-            CRM_Utils_Array::value("{$fieldName}_value", $this->_params),
-            CRM_Utils_Array::value("{$fieldName}_min", $this->_params),
-            CRM_Utils_Array::value("{$fieldName}_max", $this->_params)
+            $this->_params["{$fieldName}_op"] ?? NULL,
+            $this->_params["{$fieldName}_value"] ?? NULL,
+            $this->_params["{$fieldName}_min"] ?? NULL,
+            $this->_params["{$fieldName}_max"] ?? NULL
           );
 
         // since either OOFF or RCUR is always NULL, we can just use OR...
@@ -334,10 +334,10 @@ class CRM_Sepa_Form_Report_SepaMandateGeneric extends CRM_Report_Form {
     elseif ($fieldName == 'amount') {
       if (!empty($this->_params["{$fieldName}_value"])) {
         $base_clause = $this->whereClause($field,
-            CRM_Utils_Array::value("{$fieldName}_op", $this->_params),
-            CRM_Utils_Array::value("{$fieldName}_value", $this->_params),
-            CRM_Utils_Array::value("{$fieldName}_min", $this->_params),
-            CRM_Utils_Array::value("{$fieldName}_max", $this->_params)
+            $this->_params["{$fieldName}_op"] ?? NULL,
+            $this->_params["{$fieldName}_value"] ?? NULL,
+            $this->_params["{$fieldName}_min"] ?? NULL,
+            $this->_params["{$fieldName}_max"] ?? NULL
           );
 
         // since either OOFF or RCUR is always NULL, we can just use OR...
@@ -347,22 +347,22 @@ class CRM_Sepa_Form_Report_SepaMandateGeneric extends CRM_Report_Form {
       }
     }
 
-    elseif (CRM_Utils_Array::value('operatorType', $field) & CRM_Utils_Type::T_DATE) {
-      $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-      $from     = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-      $to       = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+    elseif (($field['operatorType'] ?? NULL) & CRM_Utils_Type::T_DATE) {
+      $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+      $from     = $this->_params["{$fieldName}_from"] ?? NULL;
+      $to       = $this->_params["{$fieldName}_to"] ?? NULL;
 
       $clause = $this->dateClause($field['name'], $relative, $from, $to, $field['type']);
     }
 
     else {
-      $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+      $op = $this->_params["{$fieldName}_op"] ?? NULL;
       if ($op) {
         $clause = $this->whereClause($field,
           $op,
-          CRM_Utils_Array::value("{$fieldName}_value", $this->_params),
-          CRM_Utils_Array::value("{$fieldName}_min", $this->_params),
-          CRM_Utils_Array::value("{$fieldName}_max", $this->_params)
+          $this->_params["{$fieldName}_value"] ?? NULL,
+          $this->_params["{$fieldName}_min"] ?? NULL,
+          $this->_params["{$fieldName}_max"] ?? NULL
         );
       }
     }
@@ -437,7 +437,7 @@ class CRM_Sepa_Form_Report_SepaMandateGeneric extends CRM_Report_Form {
         // in previous row
         $repeatFound = FALSE;
         foreach ($row as $colName => $colVal) {
-          if (CRM_Utils_Array::value($colName, $checkList) &&
+          if (!empty($checkList[$colName]) &&
             is_array($checkList[$colName]) &&
             in_array($colVal, $checkList[$colName])
           ) {

--- a/CRM/Sepa/Form/Report/SepaMandateOOFF.php
+++ b/CRM/Sepa/Form/Report/SepaMandateOOFF.php
@@ -176,13 +176,13 @@ class CRM_Sepa_Form_Report_SepaMandateOOFF extends CRM_Sepa_Form_Report_SepaMand
     $campaigns = CRM_Campaign_BAO_Campaign::getCampaigns();
 
     foreach ($rows as $rowNum => $row) {
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_financial_type_id', $row)) {
+      if ($value = $row['civicrm_contribution_financial_type_id'] ?? NULL) {
         $rows[$rowNum]['civicrm_contribution_financial_type_id'] = $contributionTypes[$value];
       }
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_contribution_status_id', $row)) {
+      if ($value = $row['civicrm_contribution_contribution_status_id'] ?? NULL) {
         $rows[$rowNum]['civicrm_contribution_contribution_status_id'] = $contributionStatus[$value];
       }
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_contribution_page_id', $row)) {
+      if ($value = $row['civicrm_contribution_contribution_page_id'] ?? NULL) {
         $rows[$rowNum]['civicrm_contribution_contribution_page_id'] = $contributionPages[$value];
       }
 
@@ -200,7 +200,7 @@ class CRM_Sepa_Form_Report_SepaMandateOOFF extends CRM_Sepa_Form_Report_SepaMand
       // convert campaign_id to campaign title
       if (array_key_exists('civicrm_contribution_campaign_id', $row)) {
         if ($value = $row['civicrm_contribution_campaign_id']) {
-          $rows[$rowNum]['civicrm_contribution_campaign_id'] = CRM_Utils_Array::value($value, $campaigns, '');
+          $rows[$rowNum]['civicrm_contribution_campaign_id'] = $campaigns[$value] ?? '';
         }
       }
     }

--- a/CRM/Sepa/Form/Report/SepaMandateRCUR.php
+++ b/CRM/Sepa/Form/Report/SepaMandateRCUR.php
@@ -232,37 +232,37 @@ class CRM_Sepa_Form_Report_SepaMandateRCUR extends CRM_Sepa_Form_Report_SepaMand
     // add amount from either OOFF or RCUR
     if ($fieldName == 'total_amount_collected') {
       $this->_columnHeaders['total_amount_collected']['title'] = $field['title'];
-      $this->_columnHeaders['total_amount_collected']['type']  = CRM_Utils_Array::value('type', $field);
+      $this->_columnHeaders['total_amount_collected']['type']  = $field['type'] ?? NULL;
       return "(SELECT/*NO_ROW_COUNT*/ SUM(total_amount) FROM civicrm_contribution total_amount_collected_contributions WHERE total_amount_collected_contributions.contribution_status_id IN (1) AND total_amount_collected_contributions.contribution_recur_id = {$this->_aliases['civicrm_contribution_recur']}.id) AS total_amount_collected";
     }
 
     if ($fieldName == 'total_count_collected') {
       $this->_columnHeaders['total_count_collected']['title'] = $field['title'];
-      $this->_columnHeaders['total_count_collected']['type']  = CRM_Utils_Array::value('type', $field);
+      $this->_columnHeaders['total_count_collected']['type']  = $field['type'] ?? NULL;
       return "(SELECT/*NO_ROW_COUNT*/ COUNT(id) FROM civicrm_contribution total_amount_collected_contributions WHERE total_amount_collected_contributions.contribution_status_id IN (1) AND total_amount_collected_contributions.contribution_recur_id = {$this->_aliases['civicrm_contribution_recur']}.id) AS total_count_collected";
     }
 
     if ($fieldName == 'total_count_failed') {
       $this->_columnHeaders['total_count_failed']['title'] = $field['title'];
-      $this->_columnHeaders['total_count_failed']['type']  = CRM_Utils_Array::value('type', $field);
+      $this->_columnHeaders['total_count_failed']['type']  = $field['type'] ?? NULL;
       return "(SELECT/*NO_ROW_COUNT*/ COUNT(id) FROM civicrm_contribution total_amount_collected_contributions WHERE total_amount_collected_contributions.contribution_status_id IN (3,4) AND total_amount_collected_contributions.contribution_recur_id = {$this->_aliases['civicrm_contribution_recur']}.id) AS total_count_failed";
     }
 
     if ($fieldName == 'contribution_count') {
       $this->_columnHeaders['contribution_count']['title'] = $field['title'];
-      $this->_columnHeaders['contribution_count']['type']  = CRM_Utils_Array::value('type', $field);
+      $this->_columnHeaders['contribution_count']['type']  = $field['type'] ?? NULL;
       return "COUNT({$this->_aliases['civicrm_contribution']}.id) AS contribution_count";
     }
 
     if ($fieldName == 'cancel_reasons') {
       $this->_columnHeaders['cancel_reasons']['title'] = $field['title'];
-      $this->_columnHeaders['cancel_reasons']['type']  = CRM_Utils_Array::value('type', $field);
+      $this->_columnHeaders['cancel_reasons']['type']  = $field['type'] ?? NULL;
       return "GROUP_CONCAT(DISTINCT({$this->_aliases['civicrm_contribution']}.cancel_reason) SEPARATOR '||') AS cancel_reasons";
     }
 
     if ($fieldName == 'cycle_interval') {
       $this->_columnHeaders['cycle_interval']['title'] = $field['title'];
-      $this->_columnHeaders['cycle_interval']['type']  = CRM_Utils_Array::value('type', $field);
+      $this->_columnHeaders['cycle_interval']['type']  = $field['type'] ?? NULL;
       return "CONCAT({$this->_aliases['civicrm_contribution_recur']}.frequency_interval, CONCAT(' ', {$this->_aliases['civicrm_contribution_recur']}.frequency_unit)) AS cycle_interval";
     }
 
@@ -300,13 +300,13 @@ class CRM_Sepa_Form_Report_SepaMandateRCUR extends CRM_Sepa_Form_Report_SepaMand
    */
   protected function _getWhereClause($fieldName, $field) {
     if ($fieldName == 'cycle_interval') {
-      $cycle_intervals = CRM_Utils_Array::value("{$fieldName}_value", $this->_params);
+      $cycle_intervals = $this->_params["{$fieldName}_value"] ?? NULL;
       if (in_array("'12 month'", $cycle_intervals)) {
         $cycle_intervals[] = "'1 year'"; // the database could have both: '1 year' and '12 month'...
       }
-      $clause = $this->whereClause($field, CRM_Utils_Array::value("{$fieldName}_op", $this->_params), $cycle_intervals,
-          CRM_Utils_Array::value("{$fieldName}_min", $this->_params),
-          CRM_Utils_Array::value("{$fieldName}_max", $this->_params)
+      $clause = $this->whereClause($field, $this->_params["{$fieldName}_op"] ?? NULL, $cycle_intervals,
+          $this->_params["{$fieldName}_min"] ?? NULL,
+          $this->_params["{$fieldName}_max"] ?? NULL
         );
       $subquery = "CONCAT({$this->_aliases['civicrm_contribution_recur']}.frequency_interval, CONCAT(' ', {$this->_aliases['civicrm_contribution_recur']}.frequency_unit))";
       $clause = preg_replace('/cycle_interval/', $subquery, $clause);
@@ -314,13 +314,13 @@ class CRM_Sepa_Form_Report_SepaMandateRCUR extends CRM_Sepa_Form_Report_SepaMand
     }
 
     if ($fieldName == 'total_amount_collected') {
-      $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+      $op = $this->_params["{$fieldName}_op"] ?? NULL;
       if ($op) {
         $clause = $this->whereClause($field,
           $op,
-          CRM_Utils_Array::value("{$fieldName}_value", $this->_params),
-          CRM_Utils_Array::value("{$fieldName}_min", $this->_params),
-          CRM_Utils_Array::value("{$fieldName}_max", $this->_params)
+          $this->_params["{$fieldName}_value"] ?? NULL,
+          $this->_params["{$fieldName}_min"] ?? NULL,
+          $this->_params["{$fieldName}_max"] ?? NULL
         );
       }
       $subquery = "(SELECT SUM(total_amount) FROM civicrm_contribution WHERE contribution_recur_id={$this->_aliases['civicrm_contribution_recur']}.id AND contribution_status_id = 1)";
@@ -329,13 +329,13 @@ class CRM_Sepa_Form_Report_SepaMandateRCUR extends CRM_Sepa_Form_Report_SepaMand
     }
 
     if ($fieldName == 'total_count_collected') {
-      $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+      $op = $this->_params["{$fieldName}_op"] ?? NULL;
       if ($op) {
         $clause = $this->whereClause($field,
           $op,
-          CRM_Utils_Array::value("{$fieldName}_value", $this->_params),
-          CRM_Utils_Array::value("{$fieldName}_min", $this->_params),
-          CRM_Utils_Array::value("{$fieldName}_max", $this->_params)
+          $this->_params["{$fieldName}_value"] ?? NULL,
+          $this->_params["{$fieldName}_min"] ?? NULL,
+          $this->_params["{$fieldName}_max"] ?? NULL
         );
       }
       $subquery = "(SELECT COUNT(DISTINCT(id)) FROM civicrm_contribution WHERE contribution_recur_id={$this->_aliases['civicrm_contribution_recur']}.id AND contribution_status_id = 1)";
@@ -344,13 +344,13 @@ class CRM_Sepa_Form_Report_SepaMandateRCUR extends CRM_Sepa_Form_Report_SepaMand
     }
 
     if ($fieldName == 'total_count_failed') {
-      $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+      $op = $this->_params["{$fieldName}_op"] ?? NULL;
       if ($op) {
         $clause = $this->whereClause($field,
           $op,
-          CRM_Utils_Array::value("{$fieldName}_value", $this->_params),
-          CRM_Utils_Array::value("{$fieldName}_min", $this->_params),
-          CRM_Utils_Array::value("{$fieldName}_max", $this->_params)
+          $this->_params["{$fieldName}_value"] ?? NULL,
+          $this->_params["{$fieldName}_min"] ?? NULL,
+          $this->_params["{$fieldName}_max"] ?? NULL
         );
       }
       $subquery = "(SELECT COUNT(DISTINCT(id)) FROM civicrm_contribution WHERE contribution_recur_id={$this->_aliases['civicrm_contribution_recur']}.id AND contribution_status_id IN (3,4))";
@@ -359,13 +359,13 @@ class CRM_Sepa_Form_Report_SepaMandateRCUR extends CRM_Sepa_Form_Report_SepaMand
     }
 
     if ($fieldName == 'cancel_reasons') {
-      $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+      $op = $this->_params["{$fieldName}_op"] ?? NULL;
       if ($op) {
         $clause = $this->whereClause($field,
           $op,
-          CRM_Utils_Array::value("{$fieldName}_value", $this->_params),
-          CRM_Utils_Array::value("{$fieldName}_min", $this->_params),
-          CRM_Utils_Array::value("{$fieldName}_max", $this->_params)
+          $this->_params["{$fieldName}_value"] ?? NULL,
+          $this->_params["{$fieldName}_min"] ?? NULL,
+          $this->_params["{$fieldName}_max"] ?? NULL
         );
       }
       $subquery = "(SELECT GROUP_CONCAT(DISTINCT({$this->_aliases['civicrm_contribution']}.cancel_reason) SEPARATOR '||') FROM civicrm_contribution WHERE contribution_recur_id={$this->_aliases['civicrm_contribution_recur']}.id AND contribution_status_id IN (3,4))";
@@ -398,16 +398,16 @@ class CRM_Sepa_Form_Report_SepaMandateRCUR extends CRM_Sepa_Form_Report_SepaMand
     $campaigns = CRM_Campaign_BAO_Campaign::getCampaigns();
 
     foreach ($rows as $rowNum => $row) {
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_recur_financial_type_id', $row)) {
+      if ($value = $row['civicrm_contribution_recur_financial_type_id'] ?? NULL) {
         $rows[$rowNum]['civicrm_contribution_recur_financial_type_id'] = $contributionTypes[$value];
       }
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_recur_contribution_status_id', $row)) {
+      if ($value = $row['civicrm_contribution_recur_contribution_status_id'] ?? NULL) {
         $rows[$rowNum]['civicrm_contribution_recur_contribution_status_id'] = $contributionStatus[$value];
       }
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_recur_contribution_page_id', $row)) {
+      if ($value = $row['civicrm_contribution_recur_contribution_page_id'] ?? NULL) {
         $rows[$rowNum]['civicrm_contribution_recur_contribution_page_id'] = $contributionPages[$value];
       }
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_contribution_status_id', $row)) {
+      if ($value = $row['civicrm_contribution_contribution_status_id'] ?? NULL) {
         $rows[$rowNum]['civicrm_contribution_contribution_status_id'] = $contributionStatus[$value];
       }
 
@@ -433,7 +433,7 @@ class CRM_Sepa_Form_Report_SepaMandateRCUR extends CRM_Sepa_Form_Report_SepaMand
       // convert campaign_id to campaign title
       if (array_key_exists('civicrm_contribution_recur_campaign_id', $row)) {
         if ($value = $row['civicrm_contribution_recur_campaign_id']) {
-          $rows[$rowNum]['civicrm_contribution_recur_campaign_id'] = CRM_Utils_Array::value($value, $campaigns, '');
+          $rows[$rowNum]['civicrm_contribution_recur_campaign_id'] = $campaigns[$value] ?? '';
         }
       }
     }

--- a/CRM/Sepa/Form/Search/SepaContactSearch.php
+++ b/CRM/Sepa/Form/Search/SepaContactSearch.php
@@ -141,7 +141,7 @@ class CRM_Sepa_Form_Search_SepaContactSearch extends CRM_Contact_Form_Search_Cus
     $count  = 1;
 
     // add reference
-    $reference = CRM_Utils_Array::value('reference', $this->_formValues);
+    $reference = $this->_formValues['reference'] ?? NULL;
     if ($reference) {
       $wheres[] = "mandate.reference LIKE %{$count}";
       $params[$count] = array($reference, 'String');
@@ -149,7 +149,7 @@ class CRM_Sepa_Form_Search_SepaContactSearch extends CRM_Contact_Form_Search_Cus
     }
 
     // add iban
-    $iban = CRM_Utils_Array::value('iban', $this->_formValues);
+    $iban = $this->_formValues['iban'] ?? NULL;
     if ($iban) {
       $wheres[] = "mandate.iban LIKE %{$count}";
       $params[$count] = array($iban, 'String');

--- a/CRM/Sepa/Logic/NextCollectionDate.php
+++ b/CRM/Sepa/Logic/NextCollectionDate.php
@@ -219,7 +219,7 @@ class CRM_Sepa_Logic_NextCollectionDate {
       }
     } elseif ($op == 'create') {
       self::$currently_edited_mandate_id = $objectId;
-      $type = CRM_Utils_Array::value('type', self::$currently_edited_mandate_params);
+      $type = self::$currently_edited_mandate_params['type'] ?? NULL;
       $update_required = ($type == 'RCUR');
     }
 
@@ -259,7 +259,7 @@ class CRM_Sepa_Logic_NextCollectionDate {
     $update_required = FALSE;
     if ($op == 'edit') {
       if (empty(self::$currently_edited_recurring_contribution_params['next_sched_contribution_date'])) {
-        $type = CRM_Utils_Array::value('type', self::$currently_edited_recurring_contribution_params);
+        $type = self::$currently_edited_recurring_contribution_params['type'] ?? NULL;
 
         $relevant_changes = array('frequency_unit', 'frequency_interval', 'start_date', 'end_date', 'cancel_date', 'contribution_status_id', 'cycle_day');
         foreach ($relevant_changes as $critical_attribute) {
@@ -278,7 +278,7 @@ class CRM_Sepa_Logic_NextCollectionDate {
 
       // if (empty(self::$currently_edited_recurring_contribution_params['next_sched_contribution_date'])) {
       //   // we want to calculate this for all RCUR mandates:
-      //   $type = CRM_Utils_Array::value('type', self::$currently_edited_recurring_contribution_params);
+      //   $type = self::$currently_edited_recurring_contribution_params['type'] ?? NULL;
       //   $update_required = ($type == 'RCUR');
       // } else {
       //   // if the date is passed, no need to calculate

--- a/CRM/Sepa/Logic/PaymentInstruments.php
+++ b/CRM/Sepa/Logic/PaymentInstruments.php
@@ -58,7 +58,7 @@ class CRM_Sepa_Logic_PaymentInstruments {
    */
   public static function getSddPaymentInstrumentID($sdd_name) {
     $all_pis = self::getSddPaymentInstruments();
-    return CRM_Utils_Array::value($sdd_name, $all_pis);
+    return $all_pis[$sdd_name] ?? NULL;
   }
 
   /**
@@ -226,7 +226,7 @@ class CRM_Sepa_Logic_PaymentInstruments {
       // collect OOFF payment instruments
       foreach ($creditors as $creditor) {
         $creditor_id = (int) $creditor['id'];
-        $creditor_pi_ooff = CRM_Utils_Array::value('pi_ooff', $creditor, '');
+        $creditor_pi_ooff = $creditor['pi_ooff'] ?? '';
         foreach (explode(',', $creditor_pi_ooff) as $pi_value) {
           $pi_id = (int) $pi_value;
           if ($pi_id) {
@@ -237,7 +237,7 @@ class CRM_Sepa_Logic_PaymentInstruments {
 
       // collect RCUR payment instruments
       foreach ($creditors as $creditor) {
-        $creditor_pi_rcur = CRM_Utils_Array::value('pi_rcur', $creditor, '');
+        $creditor_pi_rcur = $creditor['pi_rcur'] ?? '';
         foreach (explode(',', $creditor_pi_rcur) as $pi_value) {
           if (strstr($pi_value, '-')) {
             // this is a frst-rcur combo
@@ -295,7 +295,7 @@ class CRM_Sepa_Logic_PaymentInstruments {
   {
     // get the creditor
     $creditors = self::getAllSddCreditors();
-    $creditor = CRM_Utils_Array::value($creditor_id, $creditors);
+    $creditor = $creditors[$creditor_id] ?? NULL;
     if (!$creditor) {
       return []; // creditor not found
     }
@@ -367,7 +367,7 @@ class CRM_Sepa_Logic_PaymentInstruments {
     }
 
     $creditors = self::getAllSddCreditors();
-    $creditor = CRM_Utils_Array::value($creditor_id, $creditors);
+    $creditor = $creditors[$creditor_id] ?? NULL;
     if (!$creditor) {
       $cache[$creditor_id][$recurring_contribution_pi] = $recurring_contribution_pi;
       return $recurring_contribution_pi; // creditor not found
@@ -430,7 +430,7 @@ class CRM_Sepa_Logic_PaymentInstruments {
 
       // get the creditor data
       $creditors = self::getAllSddCreditors();
-      $creditor = CRM_Utils_Array::value($creditor_id, $creditors);
+      $creditor = $creditors[$creditor_id] ?? NULL;
       if ($creditor) {
         foreach (explode(',', $creditor['pi_rcur']) as $pi_spec) {
           if (strstr($pi_spec, '-')) {

--- a/CRM/Sepa/Page/CreateMandate.php
+++ b/CRM/Sepa/Page/CreateMandate.php
@@ -517,7 +517,7 @@ class CRM_Sepa_Page_CreateMandate extends CRM_Core_Page {
    * test if this page is called as a popup
    */
   protected function isPopup() {
-    return CRM_Utils_Array::value('snippet', $_REQUEST);
+    return $_REQUEST['snippet'] ?? NULL;
   }
 
   /**

--- a/Civi/Sepa/ActionProvider/Action/FindMandate.php
+++ b/Civi/Sepa/ActionProvider/Action/FindMandate.php
@@ -160,7 +160,7 @@ class FindMandate extends CreateRecurringMandate {
           $output->setParameter('amount', $recurring_contribution['amount']);
           $output->setParameter('cycle_day', $recurring_contribution['cycle_day']);
           $output->setParameter('financial_type_id', $recurring_contribution['financial_type_id']);
-          $output->setParameter('campaign_id', \CRM_Utils_Array::value('campaign_id', $recurring_contribution));
+          $output->setParameter('campaign_id', $recurring_contribution['campaign_id'] ?? NULL);
           $output->setParameter('start_date', $recurring_contribution['start_date']);
           $output->setParameter('contribution_recur_id', $recurring_contribution['id']);
 

--- a/api/v3/SepaMandate.php
+++ b/api/v3/SepaMandate.php
@@ -543,8 +543,8 @@ function civicrm_api3_sepa_mandate_terminate($params) {
   try {
     $success = CRM_Sepa_BAO_SEPAMandate::terminateMandate(
       $params['mandate_id'],
-      date('Y-m-d', strtotime(CRM_Utils_Array::value('end_date', $params, 'today'))),
-      CRM_Utils_Array::value('cancel_reason', $params),
+      date('Y-m-d', strtotime($params['end_date'] ?? 'today')),
+      $params['cancel_reason'] ?? NULL,
       FALSE);
     if ($success) {
       return civicrm_api3_create_success();

--- a/api/v3/SepaMandateLink.php
+++ b/api/v3/SepaMandateLink.php
@@ -174,11 +174,11 @@ function _civicrm_api3_sepa_mandate_link_getactive_spec(&$spec) {
 function civicrm_api3_sepa_mandate_link_getactive($params) {
   try {
     $result = CRM_Sepa_BAO_SepaMandateLink::getActiveLinks(
-        CRM_Utils_Array::value('mandate_id', $params, NULL),
-        CRM_Utils_Array::value('class', $params, NULL),
-        CRM_Utils_Array::value('entity_id', $params, NULL),
-        CRM_Utils_Array::value('entity_table', $params, NULL),
-        CRM_Utils_Array::value('date', $params, 'now'));
+        $params['mandate_id'] ?? NULL,
+        $params['class'] ?? NULL,
+        $params['entity_id'] ?? NULL,
+        $params['entity_table'] ?? NULL,
+        $params['date'] ?? 'now');
     return civicrm_api3_create_success($result);
   } catch (Exception $ex) {
     throw new API_Exception($ex->getMessage());


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.