### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Sepa/Logic/ContributionProtector.php
+++ b/CRM/Sepa/Logic/ContributionProtector.php
@@ -35,7 +35,7 @@ class CRM_Sepa_Logic_ContributionProtector implements API_Wrapper {
       }
 
       if ($error) {
-        throw new API_Exception($error);
+        throw new CRM_Core_Exception($error);
       }
     }
 

--- a/CRM/Sepa/Logic/MandateRepairs.php
+++ b/CRM/Sepa/Logic/MandateRepairs.php
@@ -328,7 +328,7 @@ class CRM_Sepa_Logic_MandateRepairs {
                 'financial_type_id' => $case->financial_type_id, // just to avoid warnings in unit tests
               ]);
               $this->log("Adjusted SEPA contribution [{$case->contribution_id}] payment instrument from [{$case->contribution_pi}] to [{$new_pi}]");
-            } catch (CiviCRM_API3_Exception $ex) {
+            } catch (CRM_Core_Exception $ex) {
               // this is probably an issue with interference with other processes, but we HAVE to fix this:
               CRM_Core_DAO::executeQuery("UPDATE civicrm_contribution SET payment_instrument_id = %1 WHERE id = %2",
                 [

--- a/Civi/Sepa/ActionProvider/Action/TerminateMandate.php
+++ b/Civi/Sepa/ActionProvider/Action/TerminateMandate.php
@@ -104,7 +104,7 @@ class TerminateMandate extends AbstractAction {
         }
         \CRM_Core_DAO::executeQuery($update, $updateParams);
       }
-      catch (\CiviCRM_API3_Exception $ex) {
+      catch (\CRM_Core_Exception $ex) {
       }
     }
   }

--- a/api/v3/SepaContributionGroup.php
+++ b/api/v3/SepaContributionGroup.php
@@ -89,7 +89,7 @@ function _civicrm_api3_sepa_contribution_group_getdetail_spec (&$params) {
 function civicrm_api3_sepa_contribution_group_getdetail($params) {
   $group = (int) $params["id"];
   if (!$group)
-    throw new API_Exception("Incorrect or missing value for group id");
+    throw new CRM_Core_Exception("Incorrect or missing value for group id");
   $sql = "
     SELECT
       contribution_id,

--- a/api/v3/SepaMandate.php
+++ b/api/v3/SepaMandate.php
@@ -98,16 +98,16 @@ function civicrm_api3_sepa_mandate_createfull($params) {
 
       } elseif (count($eligible_payment_instruments) == 0) {
         // no payment instrument -> disabled
-        throw new CiviCRM_API3_Exception("{$mandate_status} mandate for creditor ID [{$params['creditor_id']}] disabled, i.e. no valid payment instrument set.");
+        throw new CRM_Core_Exception("{$mandate_status} mandate for creditor ID [{$params['creditor_id']}] disabled, i.e. no valid payment instrument set.");
       } else {
         // unclear which one to take
-        throw new CiviCRM_API3_Exception("You have to define the payment_instrument_id for {$mandate_status} mandates for creditor ID [{$params['creditor_id']}], there are multiple options.");
+        throw new CRM_Core_Exception("You have to define the payment_instrument_id for {$mandate_status} mandates for creditor ID [{$params['creditor_id']}], there are multiple options.");
       }
 
     } else {
       // a payment instrument is set, verify that it's allowed
       if (!array_key_exists($params['payment_instrument_id'], $eligible_payment_instruments)) {
-        throw new CiviCRM_API3_Exception("Payment instrument [{$params['payment_instrument_id']}] invalid for {$mandate_status} mandates with creditor ID [{$params['creditor_id']}].");
+        throw new CRM_Core_Exception("Payment instrument [{$params['payment_instrument_id']}] invalid for {$mandate_status} mandates with creditor ID [{$params['creditor_id']}].");
       }
     }
 

--- a/api/v3/SepaMandateLink.php
+++ b/api/v3/SepaMandateLink.php
@@ -88,7 +88,7 @@ function _civicrm_api3_sepa_mandate_link_create_spec(&$spec) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 
 function civicrm_api3_sepa_mandate_link_create($params) {
@@ -100,7 +100,7 @@ function civicrm_api3_sepa_mandate_link_create($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_sepa_mandate_link_delete($params) {
   return _civicrm_api3_basic_delete('CRM_Sepa_BAO_SepaMandateLink', $params);
@@ -111,7 +111,7 @@ function civicrm_api3_sepa_mandate_link_delete($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_sepa_mandate_link_get($params) {
   return _civicrm_api3_basic_get('CRM_Sepa_BAO_SepaMandateLink', $params);
@@ -169,7 +169,7 @@ function _civicrm_api3_sepa_mandate_link_getactive_spec(&$spec) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_sepa_mandate_link_getactive($params) {
   try {
@@ -181,6 +181,6 @@ function civicrm_api3_sepa_mandate_link_getactive($params) {
         CRM_Utils_Array::value('date', $params, 'now'));
     return civicrm_api3_create_success($result);
   } catch (Exception $ex) {
-    throw new API_Exception($ex->getMessage());
+    throw new CRM_Core_Exception($ex->getMessage());
   }
 }

--- a/api/v3/SepaTransactionGroup.php
+++ b/api/v3/SepaTransactionGroup.php
@@ -167,12 +167,12 @@ function civicrm_api3_sepa_transaction_group_createnext ($params) {
   $values=array();
   $group = (int) $params["id"];
   if (!$group)
-    throw new API_Exception("Incorrect or missing value for group id");
+    throw new CRM_Core_Exception("Incorrect or missing value for group id");
   $contribs = civicrm_api("sepa_contribution_group","getdetail", $params);
 
   foreach ($contribs["values"] as $old) {
     if (!$old['recur_id'])
-      throw new API_Exception("Trying to create next payment for non-recurrent contribution?");
+      throw new CRM_Core_Exception("Trying to create next payment for non-recurrent contribution?");
     $date = strtotime(substr($old["receive_date"], 0, 10));
     $next_collectionDate = strtotime ("+". $old["frequency_interval"] . " ".$old["frequency_unit"],$date);
     $next_collectionDate = date('YmdHis', $next_collectionDate);

--- a/org.project60.sepacustom/sepacustom.php
+++ b/org.project60.sepacustom/sepacustom.php
@@ -62,7 +62,7 @@ function sepacustom_civicrm_alter_next_collection_date(&$next_collection_date, $
         $membershipEndDate->modify('+1 day');
       }
       $next_collection_date = $membershipEndDate->format('Y-m-d');
-    } catch (CiviCRM_API3_Exception $e) {
+    } catch (CRM_Core_Exception $e) {
       // No membership found.
       // Do not alter the date.
     }

--- a/tests/phpunit/CRM/Sepa/BugReproductionTest.php
+++ b/tests/phpunit/CRM/Sepa/BugReproductionTest.php
@@ -38,7 +38,7 @@ class CRM_Sepa_BugReproductionTest extends CRM_Sepa_TestBase
         'option_group_id' => 'contribution_status',
         'value' => self::CONTRIBUTION_STATUS_IN_PROGRESS,
       ]);
-    } catch (CiviCRM_API3_Exception $ex) {
+    } catch (CRM_Core_Exception $ex) {
       // this means the status is already missing, no harm done
     }
 


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.