### PR TITLE
don't check permission on getLastMandateOfContact

### DIFF
--- a/CRM/Sepa/BAO/SEPAMandate.php
+++ b/CRM/Sepa/BAO/SEPAMandate.php
@@ -896,14 +896,12 @@ class CRM_Sepa_BAO_SEPAMandate extends CRM_Sepa_DAO_SEPAMandate implements HookI
       return FALSE;
     }
 
-    $dao = CRM_Core_DAO::executeQuery(
-      "SELECT * FROM civicrm_sdd_mandate WHERE contact_id = %1 ORDER BY id DESC LIMIT 1",
-      [1 => [$cid, 'Integer']]
-    );
-    if ($dao->fetch()) {
-      return $dao->toArray();
-    }
-    return FALSE;
+    return SepaMandate::get(FALSE)
+        ->addWhere('contact_id', '=', $cid)
+        ->addOrderBy('id', 'DESC')
+        ->setLimit(1)
+        ->execute()
+        ->first() ?? FALSE;
   }
 
   public static function isContributionMandate($mandate) {

--- a/CRM/Sepa/BAO/SEPAMandate.php
+++ b/CRM/Sepa/BAO/SEPAMandate.php
@@ -902,7 +902,7 @@ class CRM_Sepa_BAO_SEPAMandate extends CRM_Sepa_DAO_SEPAMandate implements HookI
     ]);
     if ($result->fetch()) {
       // return the mandate
-      return SepaMandate::get(TRUE)
+      return SepaMandate::get(FALSE)
         ->addWhere('id', '=', $result->mandate_id)
         ->execute()
         ->single();

--- a/CRM/Sepa/BAO/SEPAMandate.php
+++ b/CRM/Sepa/BAO/SEPAMandate.php
@@ -896,20 +896,14 @@ class CRM_Sepa_BAO_SEPAMandate extends CRM_Sepa_DAO_SEPAMandate implements HookI
       return FALSE;
     }
 
-    $query = "SELECT contact_id, MAX(id) AS mandate_id FROM civicrm_sdd_mandate WHERE contact_id = %1 GROUP BY contact_id;";
-    $result = CRM_Core_DAO::executeQuery($query,[
-      1 => [$cid, 'Integer']
-    ]);
-    if ($result->fetch()) {
-      // return the mandate
-      return SepaMandate::get(FALSE)
-        ->addWhere('id', '=', $result->mandate_id)
-        ->execute()
-        ->single();
+    $dao = CRM_Core_DAO::executeQuery(
+      "SELECT * FROM civicrm_sdd_mandate WHERE contact_id = %1 ORDER BY id DESC LIMIT 1",
+      [1 => [$cid, 'Integer']]
+    );
+    if ($dao->fetch()) {
+      return $dao->toArray();
     }
-    else {
-      return FALSE;
-    }
+    return FALSE;
   }
 
   public static function isContributionMandate($mandate) {


### PR DESCRIPTION
We use civisepa in combination with civisepapp, to provide contribution pages with direct debit  (german "Lastschrift") payment processors. Filling a Contribution page, creates a contact with a SepaMandate and a according pending contribution. If someone is making a second contribution the contact is matched by the name and the mandate and the contribution is added there.

For the case that a contact is matched civisepa runs into function getLastMandateOfContact (see stacktrace below) and tries to load the last mandate of the contact. Which seems to be not neccesary. But an anonymous user has of course not the right to view mandates. There I get a permission error, and the contribution fails.

<img width="845" height="834" alt="grafik" src="https://github.com/user-attachments/assets/6097e07f-a264-4090-8a08-bc4e20c36c61" />

This PR is a quickfix to disable check permission for this api-call.

However the better question is, why in this case the last mandate of the contact is loaded. I think this is not necessary.

I also want to link PR https://github.com/Project60/org.project60.sepa/pull/767 . At the end I thought using sepapp ng payment processor would solve the described problem. This is not anymore the case. 
