### PR TITLE
Retry: pass $financial_type_id to modify_txgroup_reference()

### DIFF
--- a/CRM/Sepa/Logic/Retry.php
+++ b/CRM/Sepa/Logic/Retry.php
@@ -61,7 +61,7 @@ class CRM_Sepa_Logic_Retry {
         $counter += 1;
         $reference = "TXG-{$creditor_id}-RTRY-{$collection_date}--" . $counter;
       }
-      CRM_Utils_SepaCustomisationHooks::modify_txgroup_reference($reference, $creditor_id, 'RTRY', $collection_date);
+      CRM_Utils_SepaCustomisationHooks::modify_txgroup_reference($reference, $creditor_id, 'RTRY', $collection_date, $financial_type_id = NULL);
 
       // create new group
       $group = civicrm_api3('SepaTransactionGroup', 'create', array(

--- a/tests/phpunit/CRM/Sepa/HookTest.php
+++ b/tests/phpunit/CRM/Sepa/HookTest.php
@@ -153,8 +153,9 @@ class CRM_Sepa_HookTest extends CRM_Sepa_TestBase
    * @param string $collection_date The scheduled collection date.
    * @param string $mode The SEPA mode (OOFF, RCUR, FRST, RTRY).
    * @param string $creditor_id The SDD creditor ID.
+   * @param string $financial_type_id The financial type ID.
    */
-  function hook_civicrm_modify_txgroup_reference(string &$reference, string $creditor_id, string $mode, string $collection_date): void
+  function hook_civicrm_modify_txgroup_reference(string &$reference, string $creditor_id, string $mode, string $collection_date, string $financial_type_id): void
   {
     // Only execute this hook if we are ordered to:
     if (!$this->executeModifyTxGroupHook)


### PR DESCRIPTION
Issue #785

Pass $financial_type_id to CRM_Utils_SepaCustomisationHooks::modify_txgroup_reference(). Otherwise hook fails in PHP 8 (Too few arguments to function ...)
