### PR TITLE
Fixes issue with log file on standalone

### DIFF
--- a/CRM/Sepa/Logic/MandateRepairs.php
+++ b/CRM/Sepa/Logic/MandateRepairs.php
@@ -65,7 +65,7 @@ class CRM_Sepa_Logic_MandateRepairs {
   {
     // make sure the log file name is there
     if (!$this->log_file) {
-      $log_folder = Civi::paths()->getPath('[civicrm.files]/ConfigAndLog');
+      $log_folder = Civi::paths()->getPath('[civicrm.log]/');
       $this->log_file = $log_folder . DIRECTORY_SEPARATOR . 'CiviSEPA_repairs.log';
     }
 


### PR DESCRIPTION
On CiviCRM standalone CiviSepa fails with repairing mandates. As the log file is not in `ConfigAndLog` any more but in `private/log`. 

This PR sets CiviSepa to use `[civicrm.log]`  directory. 