### PR TITLE
Fix for 'Failed to create OOFF mandate' in the Create Mandate Screen for CiviCRM 12.1

### DIFF
--- a/js/CreateMandate.js
+++ b/js/CreateMandate.js
@@ -28,7 +28,7 @@
      * PRs welcome :)
      **/
     function sdd_setDate(fieldname, date) {
-        let dp_element = cj("#sdd-create-mandate").find("[name^=" + fieldname + "].hasDatepicker");
+        let dp_element = cj("#sdd-create-mandate").find("[name=" + fieldname + "]").siblings(".hasDatepicker");
         dp_element.datepicker('setDate', date);
 
         // flash the field a little bit to indicate change

--- a/js/CreateMandate.js
+++ b/js/CreateMandate.js
@@ -298,6 +298,7 @@
         // reset the picker without triggering change event
         sdd_getF('bank_account_preset').select2('val', '');
     }
+
     // attach earliest link handlers
     cj("#sdd-create-mandate").find("a.sdd-earliest").click(function() {
         if (cj(this).attr('id') == 'sdd_rcur_earliest') {
@@ -306,7 +307,6 @@
             sdd_setDate('ooff_date', $(this).data('date'));
         }
     });
-
 
     // attach the update methods to the various change events
     cj("#sdd-create-mandate").find("[name=interval],[name=amount],[name=cycle_day],[name^=ooff_date],[name^=rcur_start_date]").change(sdd_recalculate_fields);

--- a/js/CreateMandate.js
+++ b/js/CreateMandate.js
@@ -28,6 +28,10 @@
      * PRs welcome :)
      **/
     function sdd_setDate(fieldname, date) {
+        let date_element = cj("#sdd-create-mandate").find("[name=" + fieldname + "]");
+        let dateString = CRM.utils.formatDate(date,'yy-mm-dd');
+        // why 'yy-mm-dd' instead of  CRM.config.dateInputFormat because crm.datapicker.js line 128 has also 'yy-mm-dd'
+        date_element.val(dateString);
         let dp_element = cj("#sdd-create-mandate").find("[name=" + fieldname + "]").siblings(".hasDatepicker");
         dp_element.datepicker('setDate', date);
 
@@ -294,7 +298,6 @@
         // reset the picker without triggering change event
         sdd_getF('bank_account_preset').select2('val', '');
     }
-
     // attach earliest link handlers
     cj("#sdd-create-mandate").find("a.sdd-earliest").click(function() {
         if (cj(this).attr('id') == 'sdd_rcur_earliest') {
@@ -303,6 +306,7 @@
             sdd_setDate('ooff_date', $(this).data('date'));
         }
     });
+
 
     // attach the update methods to the various change events
     cj("#sdd-create-mandate").find("[name=interval],[name=amount],[name=cycle_day],[name^=ooff_date],[name^=rcur_start_date]").change(sdd_recalculate_fields);


### PR DESCRIPTION
When On creating an OOFF mandate the screen shows the following error.

    Error Failed to create OOFF mandate. Error was: Mandatory key(s) missing from params array: receive_date

The reason is that the collection date is not filled.

The underlying technical reason is that the datapicker works differently in CiviCRM 6. 12.1 as in CiviCRM 5