### PR TITLE
Remove unused APIv3 action `SepaSddFile.generatexml`

### DIFF
--- a/api/v3/SepaSddFile.php
+++ b/api/v3/SepaSddFile.php
@@ -82,22 +82,3 @@ function civicrm_api3_sepa_sdd_file_delete(array $params): array {
 function civicrm_api3_sepa_sdd_file_get(array $params): array {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 }
-
-/**
- * @param array<string, array<string, mixed>> $params
- */
-function _civicrm_api3_sepa_sdd_file_generatexml_spec(array &$params): void {
-  $params['id']['api.required'] = 1;
-}
-
-/**
- * FIXME: This method has no return value. Is that intended? Is that function
- * actually used?
- *
- * @param array{id: int|numeric-string} $params
- */
-function civicrm_api3_sepa_sdd_file_generatexml(array $params): void {
-  //fetch the file, then the group
-  $file = new CRM_Sepa_BAO_SEPASddFile();
-  $file->generatexml((int) $params['id']);
-}


### PR DESCRIPTION
The APIv3 action `SepaSddFile.generatexml` triggered the creation of XML content, but this content was neither returned nor persisted.