### PR TITLE
Add the IBAN and the mandate reference on the contribution list page

### DIFF
--- a/CRM/Sepa/Page/ListGroup.php
+++ b/CRM/Sepa/Page/ListGroup.php
@@ -109,6 +109,7 @@ class CRM_Sepa_Page_ListGroup extends CRM_Core_Page {
           $contribution['mandate.iban'] = $mandate['iban'];
         }
         catch (\Exception $e) {
+          // @ignoreException
         }
       }
       $contributions[] = [

--- a/CRM/Sepa/Page/ListGroup.php
+++ b/CRM/Sepa/Page/ListGroup.php
@@ -19,6 +19,7 @@ declare(strict_types = 1);
 use CRM_Sepa_ExtensionUtil as E;
 use Civi\Api4\SepaTransactionGroup;
 use Civi\Api4\Contribution;
+use Civi\Api4\SepaMandate;
 
 /**
  * back office sepa group content viewer
@@ -36,6 +37,7 @@ class CRM_Sepa_Page_ListGroup extends CRM_Core_Page {
         ->selectRowCount()
         ->addSelect(
           'id',
+          'type',
           'reference',
           'status_id',
           'COUNT(DISTINCT contribution.id) AS total_count',
@@ -63,7 +65,7 @@ class CRM_Sepa_Page_ListGroup extends CRM_Core_Page {
       );
     }
 
-    $result = Contribution::get()
+    $contributionApi = Contribution::get()
       ->selectRowCount()
       ->addSelect(
         'contact_id.display_name',
@@ -75,14 +77,40 @@ class CRM_Sepa_Page_ListGroup extends CRM_Core_Page {
         'financial_type_id',
         'financial_type_id:label',
         'campaign_id.title',
-        'contribution_status_id:label'
+        'contribution_status_id:label',
+        'mandate.reference',
+        'mandate.iban',
       )
-      ->addJoin('SepaTransactionGroup AS sepa_transaction_group', 'INNER', 'SepaContributionGroup')
+      ->addJoin('SepaTransactionGroup AS sepa_transaction_group', 'INNER', 'SepaContributionGroup');
+    if ($txGroup['type'] !== 'OOFF') {
+      // This is a recurring a group.
+      $contributionApi->addJoin('SepaMandate AS mandate', 'LEFT', NULL,
+        ['mandate.entity_table', '=', 'civicrm_contribution_recur', FALSE],
+        ['mandate.entity_id', '=', 'contribution_recur_id', TRUE]
+      );
+    }
+    $result = $contributionApi
       ->addWhere('sepa_transaction_group.id', '=', $groupId)
       ->execute();
     $statusStats = [];
     $contributions = [];
     foreach ($result as $contribution) {
+      if ($txGroup['type'] === 'OOFF') {
+        // For one off's we have to fetch the mandate per contribution
+        // There is an issue with Join between Contribution and Sepa Mandate
+        // CiviCRM core adds a join on first_contribution_id as well.
+        try {
+          $mandate = SepaMandate::get(FALSE)
+            ->addWhere('entity_table', '=', 'civicrm_contribution')
+            ->addWhere('entity_id', '=', $contribution['id'])
+            ->execute()
+            ->single();
+          $contribution['mandate.reference'] = $mandate['reference'];
+          $contribution['mandate.iban'] = $mandate['iban'];
+        }
+        catch (\Exception $e) {
+        }
+      }
       $contributions[] = [
         'contact_display_name' => $contribution['contact_id.display_name'],
         'contact_type' => $contribution['contact_id.contact_type'],
@@ -105,6 +133,8 @@ class CRM_Sepa_Page_ListGroup extends CRM_Core_Page {
         'financial_type_id' => $contribution['financial_type_id'],
         'financial_type' => $contribution['financial_type_id:label'],
         'campaign' => $contribution['campaign_id.title'],
+        'reference' => $contribution['mandate.reference'],
+        'iban' => $contribution['mandate.iban'],
       ];
       $statusStats[$contribution['contribution_status_id:label']] =
         1 + ($statusStats[$contribution['contribution_status_id:label']] ?? 0);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -49,12 +49,6 @@ parameters:
 			path: CRM/Admin/Form/Setting/SepaSettings.php
 
 		-
-			message: '#^PHPDoc tag @var with type HTML_QuickForm_select is not subtype of type HTML_QuickForm_Element\.$#'
-			identifier: varTag.type
-			count: 1
-			path: CRM/Admin/Form/Setting/SepaSettings.php
-
-		-
 			message: '#^Property CRM_Admin_Form_Setting_SepaSettings\:\:\$config_fields type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -942,12 +936,6 @@ parameters:
 			message: '#^Method CRM_Sepa_Form_Search_SepaContactSearch\:\:__construct\(\) has parameter \$formValues with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: CRM/Sepa/Form/Search/SepaContactSearch.php
-
-		-
-			message: '#^Parameter \#4 \$attributes of method CRM_Core_Form\:\:add\(\) expects array\|null, true given\.$#'
-			identifier: argument.type
-			count: 2
 			path: CRM/Sepa/Form/Search/SepaContactSearch.php
 
 		-
@@ -2246,6 +2234,18 @@ parameters:
 			path: CRM/Sepa/Page/ListGroup.php
 
 		-
+			message: '#^Cannot access offset ''mandate\.reference'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: CRM/Sepa/Page/ListGroup.php
+
+		-
+			message: '#^Cannot access offset ''mandate\.iban'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: CRM/Sepa/Page/ListGroup.php
+
+		-
 			message: '#^Cannot access offset ''contact_id\.contact_type'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
@@ -2290,7 +2290,7 @@ parameters:
 		-
 			message: '#^Cannot access offset ''id'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
+			count: 3
 			path: CRM/Sepa/Page/ListGroup.php
 
 		-
@@ -3677,12 +3677,6 @@ parameters:
 			path: api/v3/SepaSddFile.php
 
 		-
-			message: '#^Call to an undefined static method CRM_Sepa_Logic_Batching\:\:batchContributionByCreditor\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: api/v3/SepaTransactionGroup.php
-
-		-
 			message: '#^Cannot access offset ''contributions_missing_transaction'' on array\|int\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
@@ -3707,18 +3701,6 @@ parameters:
 			path: api/v3/SepaTransactionGroup.php
 
 		-
-			message: '#^Cannot access offset ''is_error'' on array\|int\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: api/v3/SepaTransactionGroup.php
-
-		-
-			message: '#^Cannot access offset ''values'' on array\|int\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: api/v3/SepaTransactionGroup.php
-
-		-
 			message: '#^Cannot cast mixed to int\.$#'
 			identifier: cast.int
 			count: 2
@@ -3732,12 +3714,6 @@ parameters:
 
 		-
 			message: '#^Only booleans are allowed in a negated boolean, int given\.$#'
-			identifier: booleanNot.exprNotBoolean
-			count: 2
-			path: api/v3/SepaTransactionGroup.php
-
-		-
-			message: '#^Only booleans are allowed in a negated boolean, int\<0, max\> given\.$#'
 			identifier: booleanNot.exprNotBoolean
 			count: 1
 			path: api/v3/SepaTransactionGroup.php
@@ -3770,12 +3746,6 @@ parameters:
 			message: '#^Part \$status_ids \(mixed\) of encapsed string cannot be cast to string\.$#'
 			identifier: encapsedStringPart.nonString
 			count: 1
-			path: api/v3/SepaTransactionGroup.php
-
-		-
-			message: '#^Variable \$total might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
 			path: api/v3/SepaTransactionGroup.php
 
 		-

--- a/templates/CRM/Sepa/Page/ListGroup.tpl
+++ b/templates/CRM/Sepa/Page/ListGroup.tpl
@@ -24,6 +24,8 @@
     <th>{ts domain="org.project60.sepa"}Contact{/ts}</th>
     <th>{ts domain="org.project60.sepa"}Financial Type{/ts}</th>
     <th>{ts domain="org.project60.sepa"}Campaign{/ts}</th>
+    <th>{ts domain="org.project60.sepa"}Reference{/ts}</th>
+    <th>{ts domain="org.project60.sepa"}IBAN{/ts}</th>
   </thead>
   <tbody>
     {foreach from=$contributions item=contribution}
@@ -36,6 +38,8 @@
       <td><a href="{$contribution.contact_link}"><div class="icon crm-icon {$contribution.contact_type}-icon"></div>{$contribution.contact_display_name}</a></td>
       <td>{$contribution.financial_type}</td>
       <td>{$contribution.campaign}</td>
+      <td>{$contribution.reference}</td>
+      <td>{$contribution.iban}</td>
     </tr>
     {/foreach}
   </tbody>


### PR DESCRIPTION
Fixes #801.

**Background**

At one of our clients we had an issue where the generated contributions ended up with all the same recurring contribution . 

This was not visible in the user interface and only visible the bank file. As each transaction was deducted from the same bank account. (So there was one donor who paid for all donors)

One of the things which would likely prevented this is when the IBAN and the mandate reference would have been visible in the UI.

**Before**

When clicking on *Contributions* next to a SEPA group no info was given on the mandate.

**After**

The mandate reference and the IBAN are visible.

<img width="2842" height="516" alt="2026-06-18_09-50" src="https://github.com/user-attachments/assets/0ddebb7e-f7cb-4b81-99c0-a99c7222c8dc" />

