### PR TITLE
Migrate APIv3 action SepaMandate.createfull to APIv4

### DIFF
--- a/CRM/Sepa/Logic/PaymentInstruments.php
+++ b/CRM/Sepa/Logic/PaymentInstruments.php
@@ -304,7 +304,7 @@ class CRM_Sepa_Logic_PaymentInstruments {
    *    one of ['OOFF', 'FRST', 'RCUR']
    *
    * @return array<int, array<string, mixed>>
-   *   list of payment instrument data
+   *   list of payment instrument data indexed by ID.
    */
   // phpcs:ignore Generic.Metrics.CyclomaticComplexity.TooHigh
   public static function getPaymentInstrumentsForCreditor(int $creditor_id, string $type): array {

--- a/Civi/Api4/SepaMandate.php
+++ b/Civi/Api4/SepaMandate.php
@@ -4,7 +4,9 @@ declare(strict_types = 1);
 
 namespace Civi\Api4;
 
+use Civi\Sepa\Api4\Action\SepaMandate\CreateFullAction;
 use Civi\Sepa\Api4\Action\SepaMandate\GetAction;
+use Civi\Sepa\Api4\Action\SepaMandate\GetFieldsAction;
 
 /**
  * SepaMandate entity.
@@ -15,8 +17,18 @@ use Civi\Sepa\Api4\Action\SepaMandate\GetAction;
  */
 class SepaMandate extends Generic\DAOEntity {
 
+  public static function createFull(bool $checkPermissions = TRUE): CreateFullAction {
+    return (new CreateFullAction(static::getEntityName(), __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
   public static function get($checkPermissions = TRUE) {
     return (new GetAction(static::getEntityName(), __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  public static function getFields($checkPermissions = TRUE) {
+    return (new GetFieldsAction(static::getEntityName(), __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 
@@ -28,7 +40,7 @@ class SepaMandate extends Generic\DAOEntity {
   public static function permissions(): array {
     return [
       'get' => ['view sepa mandates'],
-      'update' => ['edit sepa mandates'],
+      'default' => ['edit sepa mandates'],
     ];
   }
 

--- a/Civi/Sepa/Api4/Action/SepaMandate/CreateFullAction.php
+++ b/Civi/Sepa/Api4/Action/SepaMandate/CreateFullAction.php
@@ -1,0 +1,171 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Sepa\Api4\Action\SepaMandate;
+
+use Civi\Api4\Contribution;
+use Civi\Api4\ContributionRecur;
+use Civi\Api4\Generic\AbstractCreateAction;
+use Civi\Api4\Generic\Result;
+use Civi\Api4\SepaCreditor;
+use Civi\Api4\SepaMandate;
+use Civi\Sepa\Contribution\PaymentInstrumentDeterminer;
+use Civi\Sepa\Mandate\MandateStatusDeterminer;
+use Civi\Sepa\Util\ContributionUtil;
+
+final class CreateFullAction extends AbstractCreateAction {
+
+  public function _run(Result $result): void {
+    $transaction = \CRM_Core_Transaction::create();
+    $transaction->run(fn() => $this->doRun($result));
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  // phpcs:ignore Generic.Metrics.CyclomaticComplexity.TooHigh
+  public function doRun(Result $result): void {
+    $this->validateValues();
+    // TODO: more sanity checks?
+
+    /**
+     * @var array{
+     *    contact_id: int|numeric-string,
+     *    iban: string,
+     *    creditor_id?: int|numeric-string,
+     *    type: string,
+     *    status?: string,
+     *    payment_instrument_id?: int|numeric-string,
+     *    financial_type_id: int|numeric-string,
+     *    bic?: string,
+     *    contribution_contact_id?: int|numeric-string,
+     *    currency?: string,
+     *    contribution_status_id?: int|numeric-string,
+     *    amount: int|float|numeric-string,
+     *    first_contribution_id?: int|numeric-string|null,
+     *    receive_date?: ?string,
+     *    start_date?: string,
+     *    end_date?: string,
+     *    frequency_interval?: int|numeric-string,
+     *    frequency_unit?: string,
+     *    cycle_day?: int|numeric-string,
+     *    campaign_id?: int|numeric-string|null,
+     *    ...
+     *  } $values
+     */
+    $values = $this->getValues();
+
+    $values['creditor_id'] ??= $this->getDefaultCreditorId();
+
+    /** @var array{uses_bic: bool, currency: string} $creditor */
+    $creditor = SepaCreditor::get(FALSE)
+      ->addSelect('uses_bic', 'currency')
+      ->addWhere('id', '=', $values['creditor_id'])
+      ->execute()
+      ->single();
+    $values['creditor_id'] = (int) $values['creditor_id'];
+
+    $values['status'] ??= MandateStatusDeterminer::determineMandateStatus(
+      $values['type'], $values['first_contribution_id'] ?? NULL
+    );
+
+    $paymentInstrumentDeterminer = new PaymentInstrumentDeterminer();
+    $values['payment_instrument_id'] = $paymentInstrumentDeterminer->determineInitialPaymentInstrument(
+      $values['creditor_id'],
+      $values['type'],
+      isset($values['payment_instrument_id']) ? (int) $values['payment_instrument_id'] : NULL
+    );
+
+    // Validate financial type.
+    if (!array_key_exists($values['financial_type_id'], ContributionUtil::getFinancialTypeList())) {
+      throw new \CRM_Core_Exception(
+        "No permission for creating SEPA mandates with financial type [{$values['financial_type_id']}]."
+      );
+    }
+
+    // if BIC is used for this creditor, it is required (see #245)
+    if ('' === ($values['bic'] ?? '')) {
+      if ($creditor['uses_bic']) {
+        throw new \CRM_Core_Exception("BIC is required for creditor [{$values['creditor_id']}].");
+      }
+      else {
+        $values['bic'] = 'NOTPROVIDED';
+      }
+    }
+
+    // @todo Put only actual contribution values into $contributionValues.
+    $contributionValues = $values;
+    if (isset($contributionValues['contribution_contact_id'])) {
+      // in case someone wants another contact for the contribution than for the mandate...
+      $contributionValues['contact_id'] = $contributionValues['contribution_contact_id'];
+    }
+
+    $contributionValues['currency'] ??= $creditor['currency'];
+
+    if (!isset($contributionValues['contribution_status_id'])) {
+      $contributionValues['contribution_status_id:name'] ??= 'Pending';
+    }
+
+    if ($values['type'] === 'RCUR') {
+      $contributionTable  = 'civicrm_contribution_recur';
+      $contributionValues['frequency_interval'] ??= 1;
+      $contributionValues['frequency_unit'] ??= 'month';
+      $contributionValues['cycle_day'] ??= 1;
+      $contribution = ContributionRecur::create(FALSE)
+        ->setValues($contributionValues)
+        ->execute()
+        ->single();
+    }
+    elseif ($values['type'] === 'OOFF') {
+      $contributionTable  = 'civicrm_contribution';
+      $contributionValues['total_amount'] = $contributionValues['amount'];
+      $contribution = Contribution::create(FALSE)
+        ->setValues($contributionValues)
+        ->execute()
+        ->single();
+    }
+    else {
+      throw new \CRM_Core_Exception('Unknown mandate type: ' . $values['type']);
+    }
+
+    // create the mandate object itself
+    // @todo Put only actual mandate values into $mandateValues.
+    $mandateValues = $values;
+    $mandateValues['entity_table'] = $contributionTable;
+    $mandateValues['entity_id'] = $contribution['id'];
+    /** @var array<string, mixed> $mandate */
+    $mandate = SepaMandate::create($this->getCheckPermissions())
+      ->setValues($mandateValues)
+      ->execute()
+      ->single();
+
+    $result[] = $mandate;
+  }
+
+  private function getDefaultCreditorId(): int {
+    $defaultCreditor = \CRM_Sepa_Logic_Settings::defaultCreditor();
+    if ($defaultCreditor === NULL) {
+      throw new \CRM_Core_Exception('creditor_id is missing and no active default creditor is configured.');
+    }
+
+    return (int) $defaultCreditor->id;
+  }
+
+}

--- a/Civi/Sepa/Api4/Action/SepaMandate/GetFieldsAction.php
+++ b/Civi/Sepa/Api4/Action/SepaMandate/GetFieldsAction.php
@@ -1,0 +1,285 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Sepa\Api4\Action\SepaMandate;
+
+use Civi\Api4\Extension;
+use Civi\Api4\Generic\DAOGetFieldsAction;
+use Civi\Api4\Service\Spec\SpecFormatter;
+use CRM_Sepa_ExtensionUtil as E;
+
+/**
+ * @phpstan-type outputFormatterT callable(string $value, array<mixed> $row, array<string, mixed> $field): void
+ * @phpstan-type sqlRendererT callable(array<string, mixed> $field, \Civi\Api4\Query\Api4SelectQuery): string
+ * @phpstan-type fieldT array<string, array<string, scalar>|scalar[]|scalar|null|list<outputFormatterT>|sqlRendererT>
+ */
+final class GetFieldsAction extends DAOGetFieldsAction {
+
+  /**
+   * @return array<fieldT>
+   */
+  protected function getRecords(): array {
+    /** @var array<string, fieldT> $fields */
+    $fields = array_column(parent::getRecords(), NULL, 'name');
+
+    /** @see \CRM_Sepa_BAO_SEPAMandate::self_hook_civicrm_pre() */
+    $fields['creditor_id']['required'] = FALSE;
+    $fields['date']['required'] = FALSE;
+    $fields['reference']['required'] = FALSE;
+
+    if ('createFull' === $this->getAction()) {
+      unset($fields['entity_id']);
+      unset($fields['entity_table']);
+
+      $fields['contact_id']['required'] = TRUE;
+      $fields['type']['required'] = TRUE;
+      $fields['iban']['required'] = TRUE;
+
+      $fields['status']['required'] = FALSE;
+
+      // Note: For RCUR mandate the entity is actually "ContributionRecur".
+      // To load the options via SpecFormatter::getOptions() we have to use a
+      // correct entity and  cannot use something like "Contribution[Recur]".
+      $fields['payment_instrument_id'] = [
+        'type' => 'Field',
+        'entity' => 'Contribution',
+        'required' => FALSE,
+        'nullable' => FALSE,
+        'name' => 'payment_instrument_id',
+        'title' => E::ts('Payment Method ID'),
+        'data_type' => 'Integer',
+        'options' => TRUE,
+        // Suffixes are not supported. (Would be set automatically if not given or empty.)
+        'suffixes' => [''],
+        'options_callback' => [SpecFormatter::class, 'getOptions'],
+        'input_type' => 'Select',
+      ];
+
+      $fields['financial_type_id'] = [
+        'type' => 'Field',
+        'entity' => 'Contribution',
+        'required' => TRUE,
+        'nullable' => FALSE,
+        'name' => 'financial_type_id',
+        'title' => E::ts('Financial Type ID'),
+        'data_type' => 'Integer',
+        'fk_entity' => 'FinancialType',
+        'fk_column' => 'id',
+        'options' => TRUE,
+        // Suffixes are not supported. (Would be set automatically if not given or empty.)
+        'suffixes' => [''],
+        'options_callback' => [SpecFormatter::class, 'getOptions'],
+        'input_type' => 'Select',
+      ];
+
+      $fields['contribution_contact_id'] = [
+        'type' => 'Field',
+        'entity' => 'Contribution',
+        'required' => FALSE,
+        'nullable' => FALSE,
+        'name' => 'contribution_contact_id',
+        'title' => E::ts('Contact ID for contribution'),
+        'description' => E::ts('Can be used if contribution contact is different from mandate contact.'),
+        'data_type' => 'Integer',
+        'fk_entity' => 'Contact',
+        'fk_column' => 'id',
+        'input_type' => 'EntityRef',
+      ];
+
+      $fields['currency'] = [
+        'type' => 'Field',
+        'entity' => 'Contribution',
+        'required' => FALSE,
+        'nullable' => FALSE,
+        'name' => 'currency',
+        'title' => E::ts('Currency'),
+        'description' => E::ts('Creditor currency will be used if not given.'),
+        'data_type' => 'String',
+        'options' => TRUE,
+        // Suffixes are not supported. (Would be set automatically if not given or empty.)
+        'suffixes' => [''],
+        'options_callback' => [SpecFormatter::class, 'getOptions'],
+        'input_type' => 'Select',
+      ];
+
+      $fields['contribution_status_id'] = [
+        'type' => 'Field',
+        'entity' => 'Contribution',
+        'required' => FALSE,
+        'nullable' => FALSE,
+        'name' => 'contribution_status_id',
+        'title' => E::ts('Contribution Status ID'),
+        'data_type' => 'Integer',
+        'options' => TRUE,
+        // Only suffix "name" is supported.
+        'suffixes' => ['name'],
+        'options_callback' => [SpecFormatter::class, 'getOptions'],
+        'input_type' => 'Select',
+      ];
+
+      // Mapped to "total_amount" for OOFF mandates-
+      $fields['amount'] = [
+        'type' => 'Field',
+        'entity' => 'Contribution',
+        'required' => TRUE,
+        'nullable' => FALSE,
+        'name' => 'amount',
+        'title' => E::ts('Amount'),
+        'data_type' => 'Money',
+        'input_type' => 'Text',
+      ];
+
+      $fields['receive_date'] = [
+        'type' => 'Field',
+        'entity' => 'Contribution',
+        'required' => FALSE,
+        'nullable' => TRUE,
+        'name' => 'receive_date',
+        'title' => E::ts('Collection date (only for OOFF)'),
+        'data_type' => 'Timestamp',
+        'input_type' => 'Date',
+        'input_attrs' => [
+          'time' => TRUE,
+          'date' => TRUE,
+          'start_date_years' => 20,
+          'end_date_years' => 10,
+        ],
+      ];
+
+      $fields['start_date'] = [
+        'type' => 'Field',
+        'entity' => 'ContributionRecur',
+        'required' => FALSE,
+        'nullable' => FALSE,
+        'name' => 'start_date',
+        'title' => E::ts('Start of collection (only for RCUR)'),
+        'data_type' => 'Timestamp',
+        'input_type' => 'Date',
+        'input_attrs' => [
+          'time' => TRUE,
+          'date' => TRUE,
+          'start_date_years' => 20,
+          'end_date_years' => 10,
+        ],
+      ];
+
+      $fields['end_date'] = [
+        'type' => 'Field',
+        'entity' => 'ContributionRecur',
+        'required' => FALSE,
+        'nullable' => TRUE,
+        'name' => 'end_date',
+        'title' => E::ts('End of collection (only for RCUR)'),
+        'data_type' => 'Timestamp',
+        'input_type' => 'Date',
+        'input_attrs' => [
+          'time' => FALSE,
+          'date' => TRUE,
+          'start_date_years' => 20,
+          'end_date_years' => 10,
+        ],
+      ];
+
+      $fields['frequency_interval'] = [
+        'default_value' => 1,
+        'type' => 'Field',
+        'entity' => 'ContributionRecur',
+        'required' => FALSE,
+        'nullable' => FALSE,
+        'name' => 'frequency_interval',
+        'title' => E::ts('Collection interval (together with frequency_unit, only for RCUR)'),
+        'data_type' => 'Integer',
+        'input_type' => 'Text',
+      ];
+
+      $fields['frequency_unit'] = [
+        'default_value' => 'month',
+        'type' => 'Field',
+        'entity' => 'ContributionRecur',
+        'required' => FALSE,
+        'nullable' => TRUE,
+        'name' => 'frequency_unit',
+        'title' => E::ts('Collection interval unit (together with frequency_interval, only for RCUR)'),
+        'data_type' => 'String',
+        'options' => TRUE,
+        'suffixes' => [
+          'name',
+          'label',
+          'description',
+        ],
+        'options_callback' => [SpecFormatter::class, 'getOptions'],
+        'input_type' => 'Select',
+      ];
+
+      $fields['cycle_day'] = [
+        'default_value' => 1,
+        'type' => 'Field',
+        'entity' => 'ContributionRecur',
+        'required' => FALSE,
+        'nullable' => FALSE,
+        'name' => 'cycle_day',
+        'title' => E::ts('Day of the month (for collection, only for RCUR)'),
+        'data_type' => 'Integer',
+        'input_type' => 'Text',
+      ];
+
+      if ($this->isExtensionInstalled('civi_campaign')) {
+        $fields['campaign_id'] = [
+          'type' => 'Field',
+          'entity' => 'ContributionRecur',
+          'required' => FALSE,
+          'nullable' => TRUE,
+          'name' => 'campaign_id',
+          'title' => E::ts('Campaign ID'),
+          'data_type' => 'Integer',
+          'fk_entity' => 'Campaign',
+          'fk_column' => 'id',
+          'input_type' => 'EntityRef',
+        ];
+      }
+
+      $fieldsToGet = $this->_itemsToGet('name');
+      if (FALSE !== $this->loadOptions) {
+        $this->loadFieldOptions(
+          $fields,
+          $fieldsToGet ?? [
+            'payment_instrument_id',
+            'financial_type_id',
+            'currency',
+            'contribution_status_id',
+            'frequency_unit',
+          ]
+        );
+      }
+    }
+
+    return $fields;
+  }
+
+  private function isExtensionInstalled(string $extensionKey): bool {
+    return 1 === Extension::get(FALSE)
+      ->addWhere('key', '=', $extensionKey)
+      ->addWhere('status', '=', 'installed')
+      ->selectRowCount()
+      ->execute()
+      ->countMatched();
+  }
+
+}

--- a/Civi/Sepa/Contribution/PaymentInstrumentDeterminer.php
+++ b/Civi/Sepa/Contribution/PaymentInstrumentDeterminer.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Sepa\Contribution;
+
+final class PaymentInstrumentDeterminer {
+
+  /**
+   * Determines the payment instrument ID for the initial contribution when
+   * creating a new mandate.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function determineInitialPaymentInstrument(
+    int $creditorId,
+    string $mandateType,
+    ?int $givenPaymentInstrumentId
+  ): int {
+    $eligiblePaymentInstruments = \CRM_Sepa_Logic_PaymentInstruments::getPaymentInstrumentsForCreditor(
+      $creditorId,
+      $mandateType
+    );
+
+    if ([] === $eligiblePaymentInstruments) {
+      // no payment instrument -> disabled
+      throw new \CRM_Core_Exception(
+        // phpcs:ignore Generic.Files.LineLength.TooLong
+        "$mandateType mandate for creditor ID [$creditorId] disabled, i.e. no valid payment instrument set."
+      );
+    }
+
+    if (NULL === $givenPaymentInstrumentId) {
+      // no payment instrument given, see if there is a unique one set
+      if (count($eligiblePaymentInstruments) === 1) {
+        return key($eligiblePaymentInstruments);
+      }
+
+      // unclear which one to take
+      throw new \CRM_Core_Exception(
+        // phpcs:ignore Generic.Files.LineLength.TooLong
+        "You have to define the payment_instrument_id for $mandateType mandates for creditor ID [$creditorId], there are multiple options."
+      );
+    }
+
+    // a payment instrument is set, verify that it's allowed
+    if (isset($eligiblePaymentInstruments[$givenPaymentInstrumentId])) {
+      return $givenPaymentInstrumentId;
+    }
+
+    throw new \CRM_Core_Exception(
+      // phpcs:ignore Generic.Files.LineLength.TooLong
+      "Payment instrument [$givenPaymentInstrumentId] invalid for $mandateType mandates with creditor ID [$creditorId]."
+    );
+  }
+
+}

--- a/Civi/Sepa/Mandate/MandateStatusDeterminer.php
+++ b/Civi/Sepa/Mandate/MandateStatusDeterminer.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Sepa\Mandate;
+
+final class MandateStatusDeterminer {
+
+  public static function determineMandateStatus(string $type, ?int $firstContributionId): string {
+    return $type === 'OOFF' ? 'OOFF' : (NULL === $firstContributionId ? 'FRST' : 'RCUR');
+  }
+
+}

--- a/api/v3/SepaMandate.php
+++ b/api/v3/SepaMandate.php
@@ -15,6 +15,8 @@
 
 declare(strict_types = 1);
 
+use Civi\Api4\SepaMandate;
+
 /**
  * Add an SepaCreditor for a contact
  *
@@ -91,152 +93,16 @@ function _civicrm_api3_sepa_mandate_create_spec(array &$params): void {
  */
 // phpcs:ignore Generic.Metrics.CyclomaticComplexity.MaxExceeded
 function civicrm_api3_sepa_mandate_createfull(array $params): array {
-  // TODO: more sanity checks?
+  $values = $params;
+  unset($values['check_permissions']);
+  unset($values['debug']);
+  unset($values['version']);
+  $result = SepaMandate::createFull($params['check_permissions'] ?? FALSE)
+    ->setValues($values)
+    ->execute()
+    ->getArrayCopy();
 
-  // get creditor
-  try {
-    _civicrm_api3_sepa_mandate_adddefaultcreditor($params);
-    $creditor = civicrm_api3('SepaCreditor', 'getsingle', ['id' => $params['creditor_id']]);
-  }
-  catch (Exception $e) {
-    throw new Exception("Couldn't load creditor [{$params['creditor_id']}].", $e->getCode(), $e);
-  }
-
-  // verify/set payment_instrument_id
-  $mandate_status = ($params['type'] == 'OOFF') ? 'OOFF' : 'FRST';
-  // if there is a status override, use that
-  if (isset($params['status']) && $params['status'] == 'RCUR') {
-    $mandate_status = 'RCUR';
-  }
-  $rcur_pi_status = ($mandate_status == 'OOFF') ? 'OOFF' : 'RCUR';
-  $eligible_payment_instruments = CRM_Sepa_Logic_PaymentInstruments::getPaymentInstrumentsForCreditor(
-    (int) $params['creditor_id'],
-    $rcur_pi_status
-  );
-  if (empty($params['payment_instrument_id'])) {
-    // no payment instrument given, see if there is a unique one set
-    if (count($eligible_payment_instruments) == 1) {
-      // there is exactly one instrument defined -> use that
-      $params['payment_instrument_id'] = reset($eligible_payment_instruments)['id'];
-
-    }
-    elseif (count($eligible_payment_instruments) == 0) {
-      // no payment instrument -> disabled
-      throw new CRM_Core_Exception(
-        // phpcs:ignore Generic.Files.LineLength.TooLong
-        "{$mandate_status} mandate for creditor ID [{$params['creditor_id']}] disabled, i.e. no valid payment instrument set."
-      );
-    }
-    else {
-      // unclear which one to take
-      throw new CRM_Core_Exception(
-        // phpcs:ignore Generic.Files.LineLength.TooLong
-        "You have to define the payment_instrument_id for {$mandate_status} mandates for creditor ID [{$params['creditor_id']}], there are multiple options."
-      );
-    }
-
-  }
-  else {
-    // a payment instrument is set, verify that it's allowed
-    if (!array_key_exists($params['payment_instrument_id'], $eligible_payment_instruments)) {
-      throw new CRM_Core_Exception(
-        // phpcs:ignore Generic.Files.LineLength.TooLong
-        "Payment instrument [{$params['payment_instrument_id']}] invalid for {$mandate_status} mandates with creditor ID [{$params['creditor_id']}]."
-      );
-    }
-  }
-
-  // Validate financial type.
-  if (!array_key_exists($params['financial_type_id'], \Civi\Sepa\Util\ContributionUtil::getFinancialTypeList())) {
-    throw new CRM_Core_Exception(
-      "No permission for creating SEPA mandates with financial type [{$params['financial_type_id']}]."
-    );
-  }
-
-  // if BIC is used for this creditor, it is required (see #245)
-  if (empty($params['bic'])) {
-    if ($creditor['uses_bic']) {
-      return civicrm_api3_create_error("BIC is required for creditor [{$params['creditor_id']}].");
-    }
-    else {
-      $params['bic'] = 'NOTPROVIDED';
-    }
-  }
-
-  // copy array
-  $create_contribution = $params;
-  if (isset($create_contribution['contribution_contact_id'])) {
-    // in case someone wants another contact for the contribution than for the mandate...
-    $create_contribution['contact_id'] = $create_contribution['contribution_contact_id'];
-  }
-  if (empty($create_contribution['currency'])) {
-    $create_contribution['currency'] = $creditor['currency'];
-  }
-
-  if (empty($create_contribution['contribution_status_id'])) {
-    $create_contribution['contribution_status_id'] = (int) CRM_Core_PseudoConstant::getKey(
-      'CRM_Contribute_BAO_Contribution',
-      'contribution_status_id',
-      'Pending'
-    );
-  }
-
-  if ($params['type'] == 'RCUR') {
-    $contribution_entity = 'ContributionRecur';
-    $contribution_table  = 'civicrm_contribution_recur';
-    $create_contribution['payment_instrument_id'] = $params['payment_instrument_id'];
-    if (empty($create_contribution['status'])) {
-      // set default status
-      $create_contribution['status'] = 'FRST';
-    }
-    if (empty($create_contribution['is_pay_later'])) {
-      // set default pay_later
-      $create_contribution['is_pay_later'] = 1;
-    }
-
-  }
-  elseif ($params['type'] == 'OOFF') {
-    $contribution_entity = 'Contribution';
-    $contribution_table  = 'civicrm_contribution';
-    $create_contribution['payment_instrument_id'] = $params['payment_instrument_id'];
-    if (empty($create_contribution['status'])) {
-      // set default status
-      $create_contribution['status'] = 'OOFF';
-    }
-    if (empty($create_contribution['total_amount'])) {
-      // copy from amount
-      $create_contribution['total_amount'] = $create_contribution['amount'];
-    }
-
-  }
-  else {
-    return civicrm_api3_create_error('Unknown mandate type: ' . $params['type']);
-  }
-
-  // create the contribution
-  $contribution = civicrm_api3($contribution_entity, 'create', $create_contribution);
-  if (!empty($contribution['is_error'])) {
-    return $contribution;
-  }
-
-  // create the mandate object itself
-  // TODO: sanity checks
-  // copy array
-  $create_mandate = $create_contribution;
-  $create_mandate['entity_table'] = $contribution_table;
-  $create_mandate['entity_id'] = $contribution['id'];
-  /** @var array<string, mixed> $mandate */
-  $mandate = civicrm_api3('SepaMandate', 'create', $create_mandate);
-  if (!empty($mandate['is_error'])) {
-    // this didn't work, so we also have to roll back the created contribution
-    $delete = civicrm_api3($contribution_entity, 'delete', ['id' => $contribution['id']]);
-    if (!empty($delete['is_error'])) {
-      Civi::log()->debug(
-        "org.project60.sepa: createfull couldn't roll back created contribution: " . $delete['error_message']
-      );
-    }
-  }
-  return $mandate;
+  return civicrm_api3_create_success($result, $params, 'SepaMandate', 'createfull');
 }
 
 /**
@@ -510,7 +376,7 @@ function civicrm_api3_sepa_mandate_modify(array $params): array {
   // look up mandate ID if only reference is given
   if (empty($params['mandate_id']) && !empty($params['reference'])) {
     try {
-      $params['mandate_id'] = \Civi\Api4\SepaMandate::get(TRUE)
+      $params['mandate_id'] = SepaMandate::get(TRUE)
         ->addSelect('id')
         ->addWhere('reference', '=', $params['reference'])
         ->execute()
@@ -602,7 +468,7 @@ function civicrm_api3_sepa_mandate_terminate(array $params): array {
   // look up mandate ID if only reference is given
   if (empty($params['mandate_id']) && !empty($params['reference'])) {
     try {
-      $params['mandate_id'] = \Civi\Api4\SepaMandate::get(TRUE)
+      $params['mandate_id'] = SepaMandate::get(TRUE)
         ->addSelect('id')
         ->addWhere('reference', '=', $params['reference'])
         ->execute()

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3522,44 +3522,9 @@ parameters:
 			path: api/v3/SepaLogic.php
 
 		-
-			message: '#^Binary operation "\." between ''Unknown mandate…'' and mixed results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: api/v3/SepaMandate.php
-
-		-
-			message: '#^Cannot access offset ''currency'' on array\|int\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: api/v3/SepaMandate.php
-
-		-
-			message: '#^Cannot access offset ''id'' on array\|int\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
-			path: api/v3/SepaMandate.php
-
-		-
-			message: '#^Cannot access offset ''uses_bic'' on array\|int\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: api/v3/SepaMandate.php
-
-		-
-			message: '#^Cannot cast mixed to int\.$#'
-			identifier: cast.int
-			count: 1
-			path: api/v3/SepaMandate.php
-
-		-
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
 			identifier: empty.notAllowed
-			count: 21
-			path: api/v3/SepaMandate.php
-
-		-
-			message: '#^Do not throw the \\Exception base class\.$#'
-			count: 1
+			count: 10
 			path: api/v3/SepaMandate.php
 
 		-
@@ -3577,7 +3542,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 9
+			count: 2
 			path: api/v3/SepaMandate.php
 
 		-
@@ -3611,32 +3576,8 @@ parameters:
 			path: api/v3/SepaMandate.php
 
 		-
-			message: '#^Parameter \#1 \$key of function array_key_exists expects int\|string, mixed given\.$#'
-			identifier: argument.type
-			count: 2
-			path: api/v3/SepaMandate.php
-
-		-
 			message: '#^Parameter \#2 \$timestamp of function date expects int\|null, int\|false given\.$#'
 			identifier: argument.type
-			count: 1
-			path: api/v3/SepaMandate.php
-
-		-
-			message: '#^Part \$params\[''creditor_id''\] \(mixed\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
-			count: 5
-			path: api/v3/SepaMandate.php
-
-		-
-			message: '#^Part \$params\[''financial_type_id''\] \(mixed\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
-			count: 1
-			path: api/v3/SepaMandate.php
-
-		-
-			message: '#^Part \$params\[''payment_instrument_id''\] \(mixed\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
 			count: 1
 			path: api/v3/SepaMandate.php
 

--- a/tests/phpunit/CRM/Sepa/TestBase.php
+++ b/tests/phpunit/CRM/Sepa/TestBase.php
@@ -457,7 +457,7 @@ class CRM_Sepa_TestBase extends TestCase implements HeadlessInterface, HookInter
   /**
    * Get a mandate by it's ID.
    */
-  protected function getMandate(string $mandateId): array {
+  protected function getMandate(int|string $mandateId): array {
     $mandate = $this->callAPISuccessGetSingle(
       'SepaMandate',
       [


### PR DESCRIPTION
The action is now named `createFull` (with uppercase "F").

The APIv3 action is kept, but calls the APIv4 action.

I've found three issues in the previous APIv3 action that are changed in the APIv4 action:

* The type in the call of `\CRM_Sepa_Logic_PaymentInstruments::getPaymentInstrumentsForCreditor()` [here](https://github.com/Project60/org.project60.sepa/blob/a9cdfbb0a4e61f369ee2f8e67e7e1fd4689b5e4b/api/v3/SepaMandate.php#L112) (`$rcur_pi_status`) was either `'OOFF'` or `'RCUR'`, but never `'FRST'`. Though (to my understanding) it should be `'FRST'` for RCUR mandates in status `'FRST'`.
* `contribution_contact_id` overwrites `contact_id` (for `SepaMandate`), but was meant to be used only for the contribution. Reason is the assignment `$create_mandate = $create_contribution;` [here](https://github.com/Project60/org.project60.sepa/blob/a9cdfbb0a4e61f369ee2f8e67e7e1fd4689b5e4b/api/v3/SepaMandate.php#L225) that should have been `$create_mandate = $params;`.
* The field `is_pay_later` is set [here](https://github.com/Project60/org.project60.sepa/blob/a9cdfbb0a4e61f369ee2f8e67e7e1fd4689b5e4b/api/v3/SepaMandate.php#L194) when a `ContributionRecur` is created. Though only `Contribution` has this field, but not `ContributionRecur`. This field isn't set in the APIv4 action anymore. Should it be set for `Contribution`, though?

systopia-reference: 32610