### PR TITLE
Fix return value of APIv3 SepaMandate.createfull

### DIFF
--- a/api/v3/SepaMandate.php
+++ b/api/v3/SepaMandate.php
@@ -100,6 +100,7 @@ function civicrm_api3_sepa_mandate_createfull(array $params): array {
   $result = SepaMandate::createFull($params['check_permissions'] ?? FALSE)
     ->setValues($values)
     ->execute()
+    ->indexBy('id')
     ->getArrayCopy();
 
   return civicrm_api3_create_success($result, $params, 'SepaMandate', 'createfull');


### PR DESCRIPTION
In APIv3 result records have to be indexed by `id`.

Follow up of #808.

systopia-reference: 32610