### PR TITLE
Fix undefined array key warnings in mandate and group templates

### DIFF
--- a/templates/CRM/Sepa/Form/CreateMandate.tpl
+++ b/templates/CRM/Sepa/Form/CreateMandate.tpl
@@ -16,7 +16,7 @@
 <div id="sdd-create-mandate">
 
   {* hidden fields *}
-  {$form.cid.html}
+  {if !empty($form.cid)}{$form.cid.html}{/if}
 
   {if $create_mode eq 'replace'}
   <div style="background-color: paleturquoise; padding: 1em; border-radius: 1em;">

--- a/templates/CRM/Sepa/Page/CloseGroup.tpl
+++ b/templates/CRM/Sepa/Page/CloseGroup.tpl
@@ -89,7 +89,7 @@
 				<a href="{crmURL p="civicrm/sepa/closegroup" q="group_id=$txgid&status=closed"}" class="button button_export">{ts domain="org.project60.sepa"}Close it now{/ts}</a>
 			{/if}
 		{/if}
-		{if not $smarty.request.adjust}
+		{if empty($smarty.request.adjust)}
 		<a href="{crmURL p="civicrm/sepa/dashboard"}" class="button button_export">{ts domain="org.project60.sepa"}I changed my mind{/ts}</a>
 		{/if}
 	{/if}

--- a/templates/CRM/Sepa/Page/EditMandate.tpl
+++ b/templates/CRM/Sepa/Page/EditMandate.tpl
@@ -53,7 +53,7 @@
 
               </td></tr>
                 <tr><td class="label">{ts domain="org.project60.sepa"}Start Date{/ts}</td><td>{$contribution.start_date}</td></tr>
-                <tr><td class="label">{ts domain="org.project60.sepa"}End Date{/ts}</td><td>{$contribution.end_date}</td></tr>
+                <tr><td class="label">{ts domain="org.project60.sepa"}End Date{/ts}</td><td>{$contribution.end_date|default:''}</td></tr>
                 <tr><td class="label">{ts domain="org.project60.sepa"}Next Collection{/ts}</td><td>{$contribution.next_sched_contribution_date}</td></tr>
            	{else}
             	{* this is a simple contribution *}


### PR DESCRIPTION
Fixes #810, fixes #811, fixes #812

On PHP 8 these three template spots log "Undefined array key" warnings: the hidden cid field on CreateMandate, the adjust request param check on CloseGroup, and the end_date column on EditMandate. Guarded each one following the !empty style already used in EditMandate.tpl.