### PR TITLE
Fix upgrade_11304

### DIFF
--- a/CRM/Sepa/Upgrader.php
+++ b/CRM/Sepa/Upgrader.php
@@ -583,10 +583,6 @@ class CRM_Sepa_Upgrader extends CRM_Extension_Upgrader_Base {
   }
 
   public function upgrade_11304(): bool {
-    $this->ctx->log->info('Delete database index mandate_id ON civicrm_sdd_entity_mandate');
-    // There is a foreign key constraint so there's no need for an additional index.
-    $this->executeSql('DROP INDEX IF EXISTS mandate_id ON civicrm_sdd_entity_mandate');
-
     return TRUE;
   }
 


### PR DESCRIPTION
Index `mandate_id` on `civicrm_sdd_entity_mandate` cannot be deleted because it's used by a FK constraint.