### PR TITLE
Batching: do not create a second FRST installment when an open group is overdue

### DIFF
--- a/CRM/Sepa/Logic/Batching.php
+++ b/CRM/Sepa/Logic/Batching.php
@@ -231,6 +231,72 @@ class CRM_Sepa_Logic_Batching {
       /** @var array<int, array{id: int, contribution_recur_id: int, "sepa_contribution.is_on_hold": ?bool}> $existingContributionsByRecurId */
     }
 
+    // FRST-STEP 3b: reuse a pending first installment sitting in an open group with
+    // another date (e.g. an overdue group) instead of creating a second one.
+    if ('FRST' === $mode) {
+      foreach ($rcontribIdsByCollectionDate as $collectionDate => $rcontribIds) {
+        $unmatchedRecurIds = array_values(array_diff($rcontribIds, array_keys($existingContributionsByRecurId)));
+        if ([] === $unmatchedRecurIds) {
+          continue;
+        }
+        /** @var list<array{id: int, contribution_recur_id: int, "sepa_contribution.is_on_hold": ?bool, "txg.id": int}> $pendingInstallments */
+        $pendingInstallments = Contribution::get(FALSE)
+          ->addSelect('id', 'contribution_recur_id', 'sepa_contribution.is_on_hold', 'txg.id')
+          ->addJoin('SepaContributionGroup AS ctxg', 'INNER', NULL, ['ctxg.contribution_id', '=', 'id'])
+          ->addJoin('SepaTransactionGroup AS txg', 'INNER', NULL, ['txg.id', '=', 'ctxg.txgroup_id'])
+          ->addWhere('contribution_recur_id', 'IN', $unmatchedRecurIds)
+          ->addWhere('contribution_status_id:name', '=', 'Pending')
+          ->addWhere('payment_instrument_id', 'IN', $paymentInstrumentIds)
+          ->addWhere('txg.type', '=', 'FRST')
+          ->addWhere('txg.sdd_creditor_id', '=', $creditorId)
+          ->addWhere('txg.status_id', '=', $groupStatusIdOpen)
+          ->addWhere('is_test', 'IS NOT NULL')
+          ->addOrderBy('id')
+          ->execute()
+          ->getArrayCopy();
+        /** @var array<int, list<array{id: int, contribution_recur_id: int, "sepa_contribution.is_on_hold": ?bool, "txg.id": int}>> $pendingByRecurId */
+        $pendingByRecurId = [];
+        foreach ($pendingInstallments as $installment) {
+          $pendingByRecurId[$installment['contribution_recur_id']][] = $installment;
+        }
+        foreach ($pendingByRecurId as $recurId => $installments) {
+          if (count($installments) > 1) {
+            // ambiguous: neither guess nor add another one
+            $where = implode(', ', array_map(
+              fn(array $i) => "contribution {$i['id']} in group {$i['txg.id']}",
+              $installments
+            ));
+            Civi::log()->warning(
+              "org.project60.sepa: batching: recurring contribution $recurId has several pending first "
+              . "installments in open groups ($where), skipped."
+            );
+            foreach ($mandatesByCollectionDateAndFinancialTypeId[$collectionDate] as &$mandates) {
+              $mandates = array_values(array_filter(
+                $mandates,
+                /** @param array<string, mixed> $m */
+                fn(array $m) => $m['entity_id'] !== $recurId
+              ));
+            }
+            unset($mandates);
+            continue;
+          }
+          $installment = $installments[0];
+          // on-hold installments are kept out of groups by STEP 4 anyway, so leave them alone
+          if (TRUE !== $installment['sepa_contribution.is_on_hold']) {
+            Contribution::update(FALSE)
+              ->addWhere('id', '=', $installment['id'])
+              ->addValue('receive_date', $collectionDate)
+              ->execute();
+            Civi::log()->info(
+              "org.project60.sepa: batching: moved pending first installment {$installment['id']} of recurring "
+              . "contribution $recurId to $collectionDate instead of creating a duplicate."
+            );
+          }
+          $existingContributionsByRecurId[$recurId] = $installment;
+        }
+      }
+    }
+
     // RCUR-STEP 4: Create the missing contributions. Store contribution IDs
     // (existing and created) in $mandate['mandate_entity_id']. Remove mandates
     // in status "ONHOLD" so contribution won't be added to transaction group.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -26,6 +26,8 @@ When you click "Update One-Off" or "Update Recurring," CiviSEPA looks ahead base
 
 The "Close Group" action is your way of saying "this batch is ready to go to the bank." Once closed, the system generates the XML file your bank needs and locks the group to prevent accidental changes.
 
+Do not leave a group open past its submission deadline. The dashboard marks such groups as "missed", and CiviCRM's system status shows a warning listing them. Close and submit them with a new collection date, or delete them, before you run the update again. If the update does run while an overdue group is still open, a pending first collection is moved to the new collection date rather than being created a second time.
+
 ## Creating and Managing SEPA Mandates
 
 A SEPA mandate is essentially a permission slip from your supporter, allowing you to collect payments directly from their bank account. Think of it as a more sophisticated version of a standing order, but with better legal protections for both parties.

--- a/sepa.php
+++ b/sepa.php
@@ -608,3 +608,52 @@ function sepa_civicrm_xmlMenu(array &$files): void {
     $files[] = $file;
   }
 }
+
+/**
+ * Implements hook_civicrm_check().
+ *
+ * Warns about open transaction groups whose submission deadline has passed.
+ *
+ * @phpstan-param list<CRM_Utils_Check_Message> $messages
+ */
+function sepa_civicrm_check(array &$messages): void {
+  $groupStatusIdOpen = (int) CRM_Core_PseudoConstant::getKey('CRM_Batch_BAO_Batch', 'status_id', 'Open');
+  /** @var list<array{id: int, reference: string, collection_date: string}> $overdueGroups */
+  $overdueGroups = \Civi\Api4\SepaTransactionGroup::get(FALSE)
+    ->addSelect('id', 'reference', 'collection_date')
+    // empty groups are removed by the batching cleanup, nothing to act on
+    ->addJoin('SepaContributionGroup AS ctxg', 'INNER', NULL, ['ctxg.txgroup_id', '=', 'id'])
+    ->addWhere('status_id', '=', $groupStatusIdOpen)
+    ->addWhere('latest_submission_date', '<', date('Y-m-d'))
+    ->addGroupBy('id')
+    ->addOrderBy('collection_date')
+    ->execute()
+    ->getArrayCopy();
+  if ([] === $overdueGroups) {
+    return;
+  }
+  $items = [];
+  foreach ($overdueGroups as $group) {
+    $items[] = sprintf(
+      '<a href="%s">%s</a> (%s)',
+      CRM_Utils_System::url('civicrm/sepa/listgroup', "group_id={$group['id']}"),
+      htmlspecialchars($group['reference'], ENT_QUOTES, 'UTF-8'),
+      CRM_Utils_Date::customFormat($group['collection_date'])
+    );
+  }
+  $messages[] = new CRM_Utils_Check_Message(
+    'sepa_overdue_open_groups',
+    E::ts(
+      '%1 SEPA transaction group(s) are still open although their submission deadline has passed: %2. '
+      . 'Close and submit them with a new collection date, or delete them. Do not run the batching update '
+      . 'while they are open, or the affected mandates may be collected twice.',
+      [
+        1 => count($items),
+        2 => implode(', ', $items),
+      ]
+    ),
+    E::ts('Overdue open SEPA transaction groups'),
+    \Psr\Log\LogLevel::WARNING,
+    'fa-bank'
+  );
+}

--- a/tests/phpunit/CRM/Sepa/BugReproductionTest.php
+++ b/tests/phpunit/CRM/Sepa/BugReproductionTest.php
@@ -173,4 +173,141 @@ class CRM_Sepa_BugReproductionTest extends CRM_Sepa_TestBase {
     );
   }
 
+  /**
+   * A FRST group left open past its collection date must not lead to a second
+   * first installment when batching runs again; the pending one is moved.
+   */
+  public function testOverdueOpenFrstGroupIsNotDuplicated() {
+    $this->setSepaConfiguration('exclude_weekends', '0');
+    $this->setCreditorConfiguration('batching.RCUR.horizon', 30);
+    $this->setCreditorConfiguration('batching.FRST.notice', 2);
+    $this->setCreditorConfiguration('batching.RCUR.notice', 2);
+
+    $mandate = $this->createMandate(['type' => self::MANDATE_TYPE_RCUR], 'now + 5 days');
+    $this->executeBatching(self::MANDATE_TYPE_FRST);
+    $firstInstallment = $this->getLatestContributionForMandate($mandate);
+    $firstGroup = $this->getTransactionGroupForContribution($firstInstallment);
+
+    // the group is never closed; four weeks later somebody runs the batching again
+    $this->executeBatching(self::MANDATE_TYPE_FRST, 'now + 28 days');
+
+    $installments = $this->callAPISuccess('Contribution', 'get', [
+      'contribution_recur_id' => $mandate['entity_id'],
+      'options' => ['limit' => 0],
+    ])['values'];
+    $this->assertCount(1, $installments, 'A second first installment was created for the overdue open group.');
+    $installment = reset($installments);
+    $this->assertSame($firstInstallment['id'], $installment['id'], 'The pending first installment was not reused.');
+
+    $newGroup = $this->getTransactionGroupForContribution($installment);
+    $this->assertNotSame($firstGroup['id'], $newGroup['id'], 'The installment was not moved to the new group.');
+    $this->assertSameDate(
+      $newGroup['collection_date'],
+      $installment['receive_date'],
+      'receive_date was not moved to the new collection date.'
+    );
+    $this->assertCount(
+      1,
+      $this->getActiveTransactionGroups(self::MANDATE_TYPE_FRST),
+      'The emptied overdue group was not cleaned up.'
+    );
+
+    // a third run must be idempotent
+    $this->executeBatching(self::MANDATE_TYPE_FRST, 'now + 28 days');
+    $this->assertSame(1, $this->callAPISuccess('Contribution', 'getcount', [
+      'contribution_recur_id' => $mandate['entity_id'],
+    ]));
+    $mandate = $this->getMandate($mandate['id']);
+    $this->assertSame('FRST', $mandate['status']);
+    $this->assertEmpty($mandate['first_contribution_id'] ?? NULL);
+  }
+
+  /**
+   * Several pending first installments for one mandate are ambiguous: the batching must
+   * neither pick one nor add another one.
+   */
+  public function testAmbiguousPendingFirstInstallmentsAreSkipped() {
+    $this->setSepaConfiguration('exclude_weekends', '0');
+    $this->setCreditorConfiguration('batching.RCUR.horizon', 30);
+    $this->setCreditorConfiguration('batching.FRST.notice', 2);
+
+    $mandate = $this->createMandate(['type' => self::MANDATE_TYPE_RCUR], 'now + 5 days');
+    $this->executeBatching(self::MANDATE_TYPE_FRST);
+    $installment = $this->getLatestContributionForMandate($mandate);
+    $group = $this->getTransactionGroupForContribution($installment);
+
+    // fake a second pending first installment in another open group
+    $duplicate = $this->callAPISuccess('Contribution', 'create', [
+      'contact_id' => $installment['contact_id'],
+      'contribution_recur_id' => $mandate['entity_id'],
+      'financial_type_id' => $installment['financial_type_id'],
+      'payment_instrument_id' => $installment['payment_instrument_id'],
+      'total_amount' => $installment['total_amount'],
+      'receive_date' => date('Y-m-d', strtotime('now + 10 days')),
+      'contribution_status_id' => self::CONTRIBUTION_STATUS_PENDING,
+    ]);
+    $otherGroup = $this->callAPISuccess('SepaTransactionGroup', 'create', [
+      'reference' => 'TXG-TEST-FRST-AMBIGUOUS',
+      'type' => self::MANDATE_TYPE_FRST,
+      'collection_date' => date('Y-m-d', strtotime('now + 10 days')),
+      'latest_submission_date' => date('Y-m-d', strtotime('now + 8 days')),
+      'created_date' => date('Y-m-d'),
+      'status_id' => $group['status_id'],
+      'sdd_creditor_id' => $group['sdd_creditor_id'],
+    ]);
+    $this->callAPISuccess('SepaContributionGroup', 'create', [
+      'contribution_id' => $duplicate['id'],
+      'txgroup_id' => $otherGroup['id'],
+    ]);
+
+    $this->executeBatching(self::MANDATE_TYPE_FRST, 'now + 28 days');
+
+    $this->assertSame(2, $this->callAPISuccess('Contribution', 'getcount', [
+      'contribution_recur_id' => $mandate['entity_id'],
+    ]), 'A third installment was created despite the ambiguity.');
+    $this->assertSame(
+      (int) $group['id'],
+      (int) $this->getTransactionGroupForContribution($installment)['id'],
+      'The ambiguous installment was moved although it should have been skipped.'
+    );
+  }
+
+  /**
+   * The system status must warn about open groups past their submission deadline.
+   */
+  public function testOverdueOpenGroupStatusCheck() {
+    $this->setSepaConfiguration('exclude_weekends', '0');
+    $this->createMandate(['type' => self::MANDATE_TYPE_RCUR], 'now + 5 days');
+    $this->executeBatching(self::MANDATE_TYPE_FRST);
+    $group = $this->getActiveTransactionGroup(self::MANDATE_TYPE_FRST);
+
+    $messages = [];
+    sepa_civicrm_check($messages);
+    $this->assertSame([], $this->filterCheckMessages($messages), 'Check fired for a group that is not overdue.');
+
+    $this->callAPISuccess('SepaTransactionGroup', 'create', [
+      'id' => $group['id'],
+      'latest_submission_date' => date('Y-m-d', strtotime('yesterday')),
+    ]);
+    $messages = [];
+    sepa_civicrm_check($messages);
+    $this->assertCount(1, $this->filterCheckMessages($messages), 'Check did not fire for an overdue open group.');
+
+    // an emptied group is left to the batching cleanup and must not be reported
+    CRM_Core_DAO::executeQuery('DELETE FROM civicrm_sdd_contribution_txgroup WHERE txgroup_id = %1', [
+      1 => [$group['id'], 'Integer'],
+    ]);
+    $messages = [];
+    sepa_civicrm_check($messages);
+    $this->assertSame([], $this->filterCheckMessages($messages), 'Check fired for an empty group.');
+  }
+
+  /**
+   * @param list<CRM_Utils_Check_Message> $messages
+   * @return list<CRM_Utils_Check_Message>
+   */
+  private function filterCheckMessages(array $messages): array {
+    return array_values(array_filter($messages, fn($m) => $m->getName() === 'sepa_overdue_open_groups'));
+  }
+
 }


### PR DESCRIPTION
Fixes #823.

- FRST-STEP 3b in `Batching::updateRCUR`: a pending first installment in an open FRST group of the same creditor is re-dated to the new collection date and reused, so `syncGroups()` moves it and the emptied group is cleaned up. Several candidates → warning, mandate skipped for this run. On-hold installments are not re-dated.
- `hook_civicrm_check` warning for open, non-empty groups past their submission deadline.
- Tests for the overdue-group case, the ambiguous case and the status check; one paragraph in `docs/usage.md`.

Re-dating is consistent with `Group::received()` and STEP 4 and keeps the date-based lookup idempotent. RCUR is unchanged: a missed RCUR rate may legitimately be collected later.
