### PR TITLE
Upgrade: Add FK constraint for field payment_processor_id of SepaCreditor

### DIFF
--- a/CRM/Sepa/Upgrader.php
+++ b/CRM/Sepa/Upgrader.php
@@ -600,6 +600,20 @@ class CRM_Sepa_Upgrader extends CRM_Extension_Upgrader_Base {
     return TRUE;
   }
 
+  public function upgrade_11306(): bool {
+    $this->ctx->log->info('Update database schema');
+
+    E::schema()->alterSchemaField('SepaCreditor', 'payment_processor_id', [
+      'sql_type' => 'int unsigned',
+      'entity_reference' => [
+        'entity' => 'PaymentProcessor',
+        'key' => 'id',
+      ],
+    ], NULL);
+
+    return TRUE;
+  }
+
   /**
    * Helper for replacing deprecated core method
    */


### PR DESCRIPTION
The field `payment_processor_id` of `SepaCreditor` has a FK constraint since #804, but didn't have before. This PR adds an upgrade step to add that FK constraint.